### PR TITLE
fix: bootstrap pinned dependencies for source checkouts

### DIFF
--- a/Main.ahk
+++ b/Main.ahk
@@ -27,6 +27,10 @@ if (RegExMatch(A_ScriptDir, "i)\.(zip|rar)")) {
     ExitApp()
 }
 
+if (!FileExist(A_ScriptDir "\lib\OCR.ahk") || !FileExist(A_ScriptDir "\lib\JSON.ahk")) {
+    BootstrapPinnedSourceDependencies()
+}
+
 if WinExist("Ultimate Macro") {
     WinClose("Ultimate Macro")
 }
@@ -36,15 +40,73 @@ if (A_PtrSize == 4) {
 }
 
 #Include lib\Gdip_All.ahk
-#Include lib\OCR.ahk
+#Include *i lib\OCR.ahk
 #Include lib\Gdip_ImageSearch.ahk
 #Include lib\Roblox.ahk
 #Include lib\HyperSleep.ahk
 #Include lib\ImageSearch\ImageSearch.ahk
 #Include submacros\updater.ahk
-#Include lib\JSON.ahk
+#Include *i lib\JSON.ahk
 #Include lib\Discord.ahk
 #Include lib\RuntimeLog.ahk
+
+BootstrapPinnedSourceDependencies() {
+    ocrPath := A_ScriptDir "\lib\OCR.ahk"
+    jsonPath := A_ScriptDir "\lib\JSON.ahk"
+    syncScript := A_ScriptDir "\tools\sync_dependencies.ps1"
+
+    if (FileExist(ocrPath) && FileExist(jsonPath))
+        return
+
+    if !FileExist(syncScript) {
+        MsgBox(
+            "Ultimate Macro is missing its verified OCR/JSON source dependencies.`n`n"
+            "This normally means you downloaded repository source files instead of an official release.`n`n"
+            "Please download TDS_Macro.zip from GitHub Releases, or restore tools\sync_dependencies.ps1.",
+            "Missing Runtime Dependencies",
+            0x10
+        )
+        ExitApp()
+    }
+
+    powershell := A_WinDir "\System32\WindowsPowerShell\v1.0\powershell.exe"
+    quote := Chr(34)
+    command := quote powershell quote
+        . " -NoProfile -ExecutionPolicy Bypass -File "
+        . quote syncScript quote
+
+    try {
+        exitCode := RunWait(command, A_ScriptDir, "Hide")
+    } catch Error as err {
+        MsgBox(
+            "Ultimate Macro could not prepare its verified OCR/JSON dependencies.`n`n"
+            err.Message
+            "`n`nYou can also run tools\sync_dependencies.ps1 manually.",
+            "Dependency Setup Failed",
+            0x10
+        )
+        ExitApp()
+    }
+
+    if (
+        exitCode != 0
+        || !FileExist(ocrPath)
+        || !FileExist(jsonPath)
+    ) {
+        MsgBox(
+            "Verified OCR/JSON dependency setup did not complete successfully.`n`n"
+            "Check your internet connection or download the official TDS_Macro.zip release.",
+            "Dependency Setup Failed",
+            0x10
+        )
+        ExitApp()
+    }
+
+    ; Includes are processed when the script starts, so restart once the
+    ; verified files have been materialized.
+    Reload()
+    ExitApp()
+}
 
 command_buffer := []
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,19 @@ Ultimate Macro was originally created by **Darksen** on March 30, 2026. After hi
 
 ## 🧪 Development and QA
 
-Repository checkouts need two pinned source dependencies before `Main.ahk` can
-be validated. Run `pwsh ./tools/sync_dependencies.ps1`, then follow the
-automated and manual gates in [TESTING.md](TESTING.md) and
-[QA_CHECKLIST.md](QA_CHECKLIST.md).
+Official **Releases** remain the recommended download for normal users.
+
+If you intentionally clone the repository or use GitHub's **Download ZIP**,
+`OCR.ahk` and `JSON.ahk` are reproducibly materialized from immutable upstream
+revisions. You can simply run `RUN_SOURCE.bat`; `Main.ahk` also detects these
+missing files and performs the same verified bootstrap automatically before
+restarting.
+
+Developers can run the bootstrap manually with
+`pwsh ./tools/sync_dependencies.ps1`.
+
+After dependency synchronization, follow the automated and manual gates in
+[TESTING.md](TESTING.md) and [QA_CHECKLIST.md](QA_CHECKLIST.md).
 
 Dependency provenance, integrity hashes, licenses, and the optional native
 image-search status are documented in [DEPENDENCIES.md](DEPENDENCIES.md).

--- a/RUN_SOURCE.bat
+++ b/RUN_SOURCE.bat
@@ -1,0 +1,54 @@
+@echo off
+setlocal EnableExtensions
+cd /d "%~dp0"
+
+echo.
+echo ==========================================
+echo  Ultimate Macro - Source Checkout Setup
+echo ==========================================
+echo.
+echo Preparing verified OCR/JSON dependencies...
+
+if not exist "tools\sync_dependencies.ps1" (
+    echo.
+    echo ERROR: tools\sync_dependencies.ps1 is missing.
+    echo Download the official TDS_Macro.zip from GitHub Releases.
+    echo.
+    pause
+    exit /b 1
+)
+
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%CD%\tools\sync_dependencies.ps1"
+
+if errorlevel 1 (
+    echo.
+    echo ERROR: verified dependency setup failed.
+    echo.
+    pause
+    exit /b 1
+)
+
+if not exist "lib\OCR.ahk" (
+    echo ERROR: lib\OCR.ahk was not materialized.
+    pause
+    exit /b 1
+)
+
+if not exist "lib\JSON.ahk" (
+    echo ERROR: lib\JSON.ahk was not materialized.
+    pause
+    exit /b 1
+)
+
+echo.
+echo Dependencies verified.
+echo Starting Ultimate Macro...
+echo.
+
+if exist "submacros\AutoHotkey64.exe" (
+    start "" "%CD%\submacros\AutoHotkey64.exe" "%CD%\Main.ahk"
+    exit /b 0
+)
+
+start "" "%CD%\Main.ahk"
+exit /b 0

--- a/tests/test_source_contracts.py
+++ b/tests/test_source_contracts.py
@@ -19,6 +19,31 @@ def region(source: str, start: str, end: str) -> str:
     return source[start_index:end_index]
 
 
+def validate_source_dependency_bootstrap(main: str) -> None:
+    assert r"#Include *i lib\OCR.ahk" in main
+    assert r"#Include *i lib\JSON.ahk" in main
+
+    startup = region(
+        main,
+        'if (!FileExist(A_ScriptDir "\\lib\\OCR.ahk")',
+        'if WinExist("Ultimate Macro")',
+    )
+    assert "BootstrapPinnedSourceDependencies()" in startup
+
+    bootstrap = region(
+        main,
+        "BootstrapPinnedSourceDependencies() {",
+        "command_buffer := []",
+    )
+
+    assert r"tools\sync_dependencies.ps1" in bootstrap
+    assert "RunWait(" in bootstrap
+    assert "-NoProfile -ExecutionPolicy Bypass -File" in bootstrap
+    assert r"lib\OCR.ahk" in bootstrap
+    assert r"lib\JSON.ahk" in bootstrap
+    assert "Reload()" in bootstrap
+
+
 def validate_settings_contracts(main: str) -> None:
     assert re.search(
         r'global\s+UpgradeDelay\s*:=\s*IniRead\(SettingsFile,\s*"Options",\s*"UpgradeDelay",\s*200\)',
@@ -294,6 +319,7 @@ def validate(root: Path) -> None:
     safe_updater = read(root / "submacros" / "safe_update.ps1")
     wrapper = read(root / "submacros" / "update.bat")
 
+    validate_source_dependency_bootstrap(main)
     validate_settings_contracts(main)
     validate_strategy_geometry(main)
     validate_bitmap_ownership(main, watchdog, discord)


### PR DESCRIPTION
## Summary

Fixes source-checkout startup when OCR.ahk and JSON.ahk are intentionally not tracked.

### Changes
- Automatically bootstraps verified OCR/JSON dependencies for source checkouts
- Adds RUN_SOURCE.bat
- Updates source-download instructions
- Adds regression tests

### Validation
- Source regression contracts: PASS
- Repository validation: PASS
- Strategy lint: PASS
- PowerShell validation: PASS
- Safe updater smoke test: PASS
- AutoHotkey validation: PASS
- Strategy preservation during updates: PASS

This is part of the v1.3.4 release-candidate hardening in the testing repository.