### PR TITLE
fix: load JSON before updater

### DIFF
--- a/Main.ahk
+++ b/Main.ahk
@@ -45,8 +45,8 @@ if (A_PtrSize == 4) {
 #Include lib\Roblox.ahk
 #Include lib\HyperSleep.ahk
 #Include lib\ImageSearch\ImageSearch.ahk
-#Include submacros\updater.ahk
 #Include *i lib\JSON.ahk
+#Include submacros\updater.ahk
 #Include lib\Discord.ahk
 #Include lib\RuntimeLog.ahk
 

--- a/tests/test_source_contracts.py
+++ b/tests/test_source_contracts.py
@@ -23,6 +23,10 @@ def validate_source_dependency_bootstrap(main: str) -> None:
     assert r"#Include *i lib\OCR.ahk" in main
     assert r"#Include *i lib\JSON.ahk" in main
 
+    json_include = main.index(r"#Include *i lib\JSON.ahk")
+    updater_include = main.index(r"#Include submacros\updater.ahk")
+    assert json_include < updater_include, "JSON must be included before updater.ahk"
+
     startup = region(
         main,
         'if (!FileExist(A_ScriptDir "\\lib\\OCR.ahk")',


### PR DESCRIPTION
## Summary

Fixes the clean-start AutoHotkey warning where the updater referenced JSON before the JSON library was included.

## Changes

- Loads `lib\JSON.ahk` before `submacros\updater.ahk`
- Adds a regression contract enforcing the include order

## Validation

- Source regression contracts: PASS
- Repository validation: PASS
- Strategy lint: PASS
- PowerShell validation: PASS
- Safe updater smoke test: PASS
- AutoHotkey validation: PASS
- Manual runtime launch: PASS

Found during clean-install testing of the v1.3.4 release candidate.