### PR TITLE
fix: make source bootstrap portable on first launch

### DIFF
--- a/Main.ahk
+++ b/Main.ahk
@@ -20,6 +20,12 @@ ListLines(False)
 KeyHistory(0)
 SetTitleMatchMode(1)
 
+; Repository source checkouts intentionally omit pinned OCR/JSON files
+; during the first parse. Keep VarUnset warnings enabled while registering
+; these optional global dependency symbols for the bootstrap/reload flow.
+IsSet(OCR)
+IsSet(JSON)
+
 if (RegExMatch(A_ScriptDir, "i)\.(zip|rar)")) {
     MsgBox(
         "You are attempting to run the script from a ZIP file.`n`nPlease Extract/Unzip the file first, then run the script in the extracted folder.",

--- a/tests/test_source_contracts.py
+++ b/tests/test_source_contracts.py
@@ -23,6 +23,16 @@ def validate_source_dependency_bootstrap(main: str) -> None:
     assert r"#Include *i lib\OCR.ahk" in main
     assert r"#Include *i lib\JSON.ahk" in main
 
+    assert "IsSet(OCR)" in main
+    assert "IsSet(JSON)" in main
+
+    first_boot_call = main.index("BootstrapPinnedSourceDependencies()")
+    assert main.index("IsSet(OCR)") < first_boot_call
+    assert main.index("IsSet(JSON)") < first_boot_call
+
+    # Never solve first-boot dependency handling by hiding genuine warnings.
+    assert "#Warn VarUnset, Off" not in main
+
     json_include = main.index(r"#Include *i lib\JSON.ahk")
     updater_include = main.index(r"#Include submacros\updater.ahk")
     assert json_include < updater_include, "JSON must be included before updater.ahk"
@@ -46,6 +56,19 @@ def validate_source_dependency_bootstrap(main: str) -> None:
     assert r"lib\OCR.ahk" in bootstrap
     assert r"lib\JSON.ahk" in bootstrap
     assert "Reload()" in bootstrap
+
+
+
+def validate_dependency_bootstrap_portability(root: Path) -> None:
+    sync = read(root / "tools" / "sync_dependencies.ps1")
+
+    assert "Get-FileHash" not in sync
+    assert "Get-Command git" not in sync
+    assert "hash-object" not in sync
+
+    assert "System.Security.Cryptography.SHA256" in sync
+    assert "System.Security.Cryptography.SHA1" in sync
+    assert 'Get-GitBlobHash' in sync
 
 
 def validate_settings_contracts(main: str) -> None:
@@ -324,6 +347,7 @@ def validate(root: Path) -> None:
     wrapper = read(root / "submacros" / "update.bat")
 
     validate_source_dependency_bootstrap(main)
+    validate_dependency_bootstrap_portability(root)
     validate_settings_contracts(main)
     validate_strategy_geometry(main)
     validate_bitmap_ownership(main, watchdog, discord)

--- a/tools/sync_dependencies.ps1
+++ b/tools/sync_dependencies.ps1
@@ -23,17 +23,56 @@ $dependencies = @(
     }
 )
 
-function Get-GitBlobHash([string]$Path) {
-    $git = Get-Command git -ErrorAction Stop
-    $hash = & $git.Source hash-object -- $Path
-    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($hash)) {
-        throw "git hash-object failed for $Path"
+function Get-FileDigest([string]$Path, [string]$Algorithm) {
+    $stream = [System.IO.File]::OpenRead($Path)
+
+    try {
+        switch ($Algorithm.ToUpperInvariant()) {
+            'SHA256' {
+                $hasher = [System.Security.Cryptography.SHA256]::Create()
+            }
+            'SHA1' {
+                $hasher = [System.Security.Cryptography.SHA1]::Create()
+            }
+            default {
+                throw "Unsupported hash algorithm: $Algorithm"
+            }
+        }
+
+        try {
+            $hash = $hasher.ComputeHash($stream)
+            return ([System.BitConverter]::ToString($hash) -replace '-', '').ToLowerInvariant()
+        }
+        finally {
+            $hasher.Dispose()
+        }
     }
-    return $hash.Trim().ToLowerInvariant()
+    finally {
+        $stream.Dispose()
+    }
+}
+
+function Get-GitBlobHash([string]$Path) {
+    $bytes = [System.IO.File]::ReadAllBytes($Path)
+    $header = [System.Text.Encoding]::ASCII.GetBytes("blob $($bytes.Length)`0")
+
+    $payload = New-Object byte[] ($header.Length + $bytes.Length)
+    [System.Buffer]::BlockCopy($header, 0, $payload, 0, $header.Length)
+    [System.Buffer]::BlockCopy($bytes, 0, $payload, $header.Length, $bytes.Length)
+
+    $sha1 = [System.Security.Cryptography.SHA1]::Create()
+
+    try {
+        $hash = $sha1.ComputeHash($payload)
+        return ([System.BitConverter]::ToString($hash) -replace '-', '').ToLowerInvariant()
+    }
+    finally {
+        $sha1.Dispose()
+    }
 }
 
 function Assert-DependencyHash([string]$Path, [hashtable]$Dependency) {
-    $actualSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $Path).Hash.ToLowerInvariant()
+    $actualSha256 = Get-FileDigest $Path 'SHA256'
     if ($actualSha256 -ne $Dependency.Sha256) {
         throw "SHA-256 verification failed for $($Dependency.Name). Expected $($Dependency.Sha256), got $actualSha256."
     }


### PR DESCRIPTION
## Summary

Fixes clean first-launch startup when OCR/JSON are intentionally absent from repository source checkouts.

## Changes

- Prevents first-parse OCR/JSON VarUnset warnings without disabling #Warn
- Makes dependency hashing self-contained with .NET
- Removes bootstrap dependency on Get-FileHash and git hash-object
- Preserves pinned SHA-256 and Git blob verification
- Adds regression contracts for first-boot and bootstrap portability

## Validation

- Source regression contracts: PASS
- Repository validation: PASS
- Strategy lint: PASS
- PowerShell validation: PASS
- Safe updater smoke test: PASS
- AutoHotkey validation: PASS
- Clean first-boot test: PASS
- OCR/JSON absent before launch: confirmed
- OCR/JSON automatically materialized after launch: confirmed
- GUI launch after bootstrap/reload: PASS