### PR TITLE
fix: use official release repository for updates

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -47,7 +47,7 @@ Primary provenance references:
 - <https://github.com/thqby/ahk2_lib/tree/4d1fe28493bcb665d7fcccce1289ed9a36df4ff0>
 - <https://github.com/opencv/opencv/releases/tag/5.0.0>
 - <https://learn.microsoft.com/cpp/windows/latest-supported-vc-redist>
-- <https://github.com/UltimateMacro/Ultimate-Macro-New-Era/releases/tag/v1.3.3>
+- <https://github.com/DarksenDev/tds-macro/releases/tag/1.3.3>
 
 ## Changes to port
 
@@ -213,3 +213,14 @@ Manual QA remains required for Roblox image clicks at representative client
 sizes, a full strategy run, recording/settings persistence, webhook/bot sends
 with disposable credentials, watchdog recovery, and a disposable-install
 updater test.
+
+## Release updater repository migration
+
+- Point only latest-release discovery and release-asset allowlists at
+  `DarksenDev/tds-macro`.
+- Keep the development and community strategy source on
+  `UltimateMacro/Ultimate-Macro-New-Era`.
+- Extend repository/source contracts to require the official release endpoints
+  and reject the retired release lookup/download paths.
+- Run all repository, PowerShell, updater-smoke, and AutoHotkey validation gates.
+- Leave the result uncommitted and unpushed for manual review as requested.

--- a/TESTING.md
+++ b/TESTING.md
@@ -81,7 +81,7 @@ Use only disposable test credentials and remove them afterward.
 
 Use a disposable extracted release copy, never this Git checkout.
 
-1. Confirm the updater reads `UltimateMacro/Ultimate-Macro-New-Era` and does
+1. Confirm the updater reads releases from `DarksenDev/tds-macro` and does
    not offer a downgrade or same-version reinstall.
 2. Confirm the chosen asset is `TDS_Macro.zip` and has a GitHub `sha256:`
    digest before accepting the prompt.

--- a/submacros/safe_update.ps1
+++ b/submacros/safe_update.ps1
@@ -51,7 +51,7 @@ function Assert-DownloadUrl([string]$Value) {
         throw 'The release supplied an invalid download URL.'
     }
     $official = $uri.Scheme -eq 'https' -and $uri.Host -eq 'github.com' -and
-        $uri.AbsolutePath.StartsWith('/UltimateMacro/Ultimate-Macro-New-Era/releases/download/', [StringComparison]::OrdinalIgnoreCase)
+        $uri.AbsolutePath.StartsWith('/DarksenDev/tds-macro/releases/download/', [StringComparison]::OrdinalIgnoreCase)
     $loopbackTest = $uri.Scheme -eq 'http' -and $uri.IsLoopback
     if (-not ($official -or $loopbackTest)) {
         throw "Untrusted update URL rejected: $Value"

--- a/submacros/updater.ahk
+++ b/submacros/updater.ahk
@@ -5,7 +5,7 @@ if (A_LineFile = A_ScriptFullPath)
     ExitApp()
 
 CheckForUpdate(currentVer) {
-    static ReleaseApi := "https://api.github.com/repos/UltimateMacro/Ultimate-Macro-New-Era/releases/latest"
+    static ReleaseApi := "https://api.github.com/repos/DarksenDev/tds-macro/releases/latest"
     static PreferredAsset := "TDS_Macro.zip"
 
     try {
@@ -45,7 +45,7 @@ CheckForUpdate(currentVer) {
                 candidateURL := asset["browser_download_url"]
                 candidateDigest := asset["digest"]
                 if !RegExMatch(candidateURL,
-                    "i)^https://github\.com/UltimateMacro/Ultimate-Macro-New-Era/releases/download/")
+                    "i)^https://github\.com/DarksenDev/tds-macro/releases/download/")
                     continue
                 if !RegExMatch(candidateDigest, "i)^sha256:[0-9a-f]{64}$")
                     continue

--- a/tests/test_source_contracts.py
+++ b/tests/test_source_contracts.py
@@ -297,16 +297,20 @@ def validate_multipart_handles(main: str, watchdog: str, discord: str) -> None:
     ), "Discord multipart HGLOBAL must be released in finally"
 
 def validate_transactional_updater(updater: str, safe_updater: str, wrapper: str) -> None:
-    assert "UltimateMacro/Ultimate-Macro-New-Era/releases/latest" in updater
+    assert "https://api.github.com/repos/DarksenDev/tds-macro/releases/latest" in updater
+    assert r"https://github\.com/DarksenDev/tds-macro/releases/download/" in updater
     assert 'PreferredAsset := "TDS_Macro.zip"' in updater
     assert "JSON.parse" in updater
     assert 'RegExMatch(candidateDigest, "i)^sha256:[0-9a-f]{64}$")' in updater
     assert "CompareMacroVersions(latestVer, installedVer) <= 0" in updater
     assert "GetCurrentProcessId" in updater
     assert 'command .= " -SelfDelete"' in updater
-    assert "DarksenDev/tds-macro" not in updater
+    assert "UltimateMacro/Ultimate-Macro-New-Era/releases/latest" not in updater
+    assert "UltimateMacro/Ultimate-Macro-New-Era/releases/download" not in updater
 
     assert "[Parameter(Mandatory = $true)][string]$ExpectedSha256" in safe_updater
+    assert "/DarksenDev/tds-macro/releases/download/" in safe_updater
+    assert "UltimateMacro/Ultimate-Macro-New-Era/releases/download" not in safe_updater
     assert "Refusing to update a filesystem root" in safe_updater
     assert "does not contain Main.ahk" in safe_updater
     assert "A .git entry was detected" in safe_updater

--- a/tests/validate_repo.py
+++ b/tests/validate_repo.py
@@ -248,7 +248,8 @@ def validate_updater(root: Path, errors: list[str]) -> None:
     wrapper = read_text(root / "submacros" / "update.bat")
 
     updater_markers = (
-        "UltimateMacro/Ultimate-Macro-New-Era/releases/latest",
+        "https://api.github.com/repos/DarksenDev/tds-macro/releases/latest",
+        r"https://github\.com/DarksenDev/tds-macro/releases/download/",
         'PreferredAsset := "TDS_Macro.zip"',
         "JSON.parse",
         'asset["digest"]',
@@ -258,6 +259,7 @@ def validate_updater(root: Path, errors: list[str]) -> None:
     )
     safe_markers = (
         "Assert-InstallRoot",
+        "/DarksenDev/tds-macro/releases/download/",
         "Normalize-Sha256",
         "Assert-SafeZip",
         "Assert-RuntimePayload",
@@ -273,8 +275,12 @@ def validate_updater(root: Path, errors: list[str]) -> None:
         if marker not in safe:
             fail(errors, f"safe updater contract is missing: {marker}")
 
-    if "DarksenDev/tds-macro" in updater:
+    if "UltimateMacro/Ultimate-Macro-New-Era/releases/latest" in updater:
         fail(errors, "updater still references the retired release repository")
+    if "UltimateMacro/Ultimate-Macro-New-Era/releases/download" in updater:
+        fail(errors, "updater still allows assets from the retired release repository")
+    if "UltimateMacro/Ultimate-Macro-New-Era/releases/download" in safe:
+        fail(errors, "safe updater still allows assets from the retired release repository")
     if "checksum verification was skipped" in safe.casefold():
         fail(errors, "safe updater permits installation without a checksum")
     for destructive in ("del /f /s /q", "rd /s /q", "Expand-Archive"):


### PR DESCRIPTION
## Summary

Moves updater release lookup and download validation to the official release repository:

DarksenDev/tds-macro

## Validation

- Source contracts: PASS
- Repository validation: PASS
- Strategy lint: PASS
- PowerShell validation: PASS
- Safe updater smoke: PASS
- AutoHotkey validation: PASS
- git diff --check: PASS

Community strategies remain sourced from UltimateMacro/Ultimate-Macro-New-Era.
No public release was created.