### PR TITLE
fix: harden watchdog lifecycle against unset PID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- Watchdog PID cleanup raising `VarUnset` after an incomplete launch, repeated
+  cleanup/start cycle, or an early Main exit. Launch now publishes only a
+  successful local PID, while cleanup is idempotent, path-scoped, and logged.
 - Multi-scale portable image detection when optional OpenCV binaries are absent.
 - Frost and standard difficulty selection with bounded scroll + OCR fallback.
 - The resettable Easy/difficulty timeout that could still hang indefinitely.

--- a/Main.ahk
+++ b/Main.ahk
@@ -8650,29 +8650,55 @@ startWatchdog() {
     KillSubmacros()
 
     currentPID := DllCall("GetCurrentProcessId")
-    if (A_PtrSize == 4) {
-        Run('"' A_ScriptDir '\submacros\AutoHotkey32.exe" "' A_ScriptDir '\submacros\watchdog.ahk" ' currentPID, , , &
-            watchdogPID)
-    } else {
-        Run('"' A_ScriptDir '\submacros\AutoHotkey64.exe" "' A_ScriptDir '\submacros\watchdog.ahk" ' currentPID, , , &
-            watchdogPID)
+    watchdogExe := A_ScriptDir "\submacros\" (A_PtrSize == 4 ? "AutoHotkey32.exe" : "AutoHotkey64.exe")
+    watchdogScript := A_ScriptDir "\submacros\watchdog.ahk"
+    command := '"' watchdogExe '" "' watchdogScript '" ' currentPID
+    newWatchdogPID := 0
+
+    try {
+        Run(command, , , &newWatchdogPID)
+        if (!IsSet(newWatchdogPID) || newWatchdogPID = "" || newWatchdogPID <= 0)
+            throw Error("Run did not return a watchdog process ID.")
+
+        watchdogPID := newWatchdogPID
+        RuntimeLogInfo("watchdog_started", "Watchdog process launched",
+            "watchdog_pid=" watchdogPID "; main_pid=" currentPID)
+        return true
+    } catch Error as err {
+        watchdogPID := ""
+        RuntimeLogError("watchdog_start_failed", "Could not launch watchdog; Main will continue without it",
+            "main_pid=" currentPID "; error=" err.Message)
+        return false
     }
 }
 
 KillSubmacros() {
     global watchdogPID
 
+    trackedPID := ""
+    if (IsSet(watchdogPID) && watchdogPID != "")
+        trackedPID := watchdogPID
+
+    ; Publish the idle state before cleanup so repeated calls are idempotent.
+    watchdogPID := ""
+
     ; Prefer the exact PID returned when this installation launched watchdog.
-    if (watchdogPID != "") {
+    if (trackedPID != "") {
         try {
-            if ProcessExist(watchdogPID)
-                ProcessClose(watchdogPID)
+            if ProcessExist(trackedPID) {
+                ProcessClose(trackedPID)
+                RuntimeLogInfo("watchdog_stopped", "Stopped tracked watchdog process",
+                    "watchdog_pid=" trackedPID "; source=tracked_pid")
+            }
+        } catch Error as err {
+            RuntimeLogWarn("watchdog_cleanup_failed", "Could not close tracked watchdog process",
+                "watchdog_pid=" trackedPID "; source=tracked_pid; error=" err.Message)
         }
-        watchdogPID := ""
     }
 
     ; Fallback cleanup is path-scoped so another checkout/instance is untouched.
     targetScript := StrLower(StrReplace(A_ScriptDir "\submacros\watchdog.ahk", "/", "\"))
+    pathClosed := 0
     try {
         for process in ComObjGet("winmgmts:").ExecQuery(
             "SELECT * FROM Win32_Process WHERE Name = 'AutoHotkey64.exe' OR Name = 'AutoHotkey.exe' OR Name = 'AutoHotkey32.exe'"
@@ -8682,21 +8708,39 @@ KillSubmacros() {
                 if (cmd = "")
                     continue
                 normalizedCmd := StrLower(StrReplace(cmd, "/", "\"))
-                if InStr(normalizedCmd, targetScript)
-                    try ProcessClose(process.ProcessId)
+                if InStr(normalizedCmd, targetScript) {
+                    try {
+                        ProcessClose(process.ProcessId)
+                        pathClosed += 1
+                    } catch Error as err {
+                        RuntimeLogWarn("watchdog_cleanup_failed", "Could not close path-scoped watchdog process",
+                            "watchdog_pid=" process.ProcessId "; source=path_scan; error=" err.Message)
+                    }
+                }
             }
         }
+    } catch Error as err {
+        RuntimeLogWarn("watchdog_cleanup_scan_failed", "Could not scan for path-scoped watchdog processes",
+            "target=" targetScript "; error=" err.Message)
     }
+
+    if (pathClosed > 0)
+        RuntimeLogInfo("watchdog_stopped", "Stopped path-scoped watchdog process",
+            "count=" pathClosed "; source=path_scan")
 }
 
 HandleExit(ExitReason, ExitCode) {
-    global StateFile, SettingsFile
+    global StateFile, SettingsFile, RunningStrategy
 
     ; Never leave a mouse button or movement key latched down for the user.
     try ReleaseHeldInput()
 
-    if (RunningStrategy) {
-        KillSubmacros()
+    try KillSubmacros()
+    catch Error as err
+        RuntimeLogWarn("watchdog_exit_cleanup_failed", "Watchdog cleanup failed during Main exit",
+            "reason=" ExitReason "; error=" err.Message)
+
+    if (IsSet(RunningStrategy) && RunningStrategy) {
         if (ExitReason = "Close" || ExitReason = "Menu" || ExitReason = "Shutdown" || ExitReason = "Logoff") {
             IniWrite(0, StateFile, "State", "Running")
             IniDelete(StateFile, "State", "Strategy")

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,3 +1,67 @@
+# Watchdog PID lifecycle hotfix — 2026-09-02
+
+Target: local-only `fix/watchdog-pid-unset` from canonical `upstream/dev` at
+`1726fdaa0b6dea91ecc04cfbb5d0a31cc5796012`. Do not commit or push before
+manual Roblox QA approval. Preserve Darksen as Original Creator, GPL-3.0,
+TimeScale behavior, and path-scoped watchdog cleanup.
+
+## Root-cause constraints
+
+- `watchdogPID` has a normal startup initializer, but `startWatchdog()` passes
+  that global directly to `Run(..., &watchdogPID)`. An output-variable failure
+  can therefore leave the shared lifecycle variable unset before later cleanup.
+- `KillSubmacros()` reads the PID without `IsSet`, so repeated cleanup or a
+  cleanup after an incomplete launch can raise `VarUnset` instead of behaving
+  idempotently.
+- `OnExit(HandleExit)` is registered before the later `watchdogPID` and
+  `RunningStrategy` startup initializers execute. Early-exit cleanup must also
+  tolerate that initialization window.
+- `watchdogPID` is the only mutable `Run` output PID in Main. The watchdog's
+  `MainPID` is a required process argument and is not affected by this bug.
+
+## Local change plan
+
+1. Harden `startWatchdog()` with an initialized local output PID, publish it to
+   the global only after a successful launch, and return false with a structured
+   `watchdog_start_failed` log if launch fails.
+2. Make `KillSubmacros()` consume the tracked PID only behind `IsSet`, clear the
+   global before cleanup work, retain the exact-PID and path-scoped fallbacks,
+   and log `watchdog_stopped`, `watchdog_cleanup_failed`, or
+   `watchdog_cleanup_scan_failed` as appropriate.
+3. Make `HandleExit()` attempt idempotent watchdog cleanup regardless of
+   partially initialized running state, protect `RunningStrategy` with `IsSet`,
+   and log `watchdog_exit_cleanup_failed` if the cleanup boundary itself fails.
+4. Extend existing source contracts for initialization, repeated cleanup/start
+   safety, local PID publication, failed-launch recovery, path isolation, and
+   defensive OnExit ordering. Update CHANGELOG/TESTING with exact manual gates.
+
+## Local verification gates
+
+- Run all Python contracts/validators and strategy lint, PowerShell parsing,
+  updater smoke tests, AutoHotkey 2.0.12 and verified 2.0.26 `/Validate`, and
+  `git diff --check`.
+- Inspect every `startWatchdog`, `KillSubmacros`, `HandleExit`, Reload,
+  restart, reconnect, Play Again, start/stop, and watchdog recovery call path.
+- Confirm no TimeScale hunk, no unscoped process termination, no unrelated PID
+  refactor, and no attribution/license change.
+- Stop with uncommitted local changes and provide the manual Roblox matrix plus
+  exact runtime event names. Wait for explicit approval before committing or
+  pushing `fix/watchdog-pid-unset`.
+
+## QA sign-off
+
+- Automated repository, source-contract, strategy, PowerShell, updater, and
+  AutoHotkey 2.0.12/2.0.26 validation passed locally.
+- Manual AutoHotkey 2.0.12 Roblox QA passed with TimeScale OFF and 2x: no
+  `watchdogPID` `VarUnset`, successful stop and completed strategy, exactly one
+  watchdog process, native OpenCV active, and no watchdog failure/cleanup log
+  events.
+- Manual approval to commit and push only `fix/watchdog-pid-unset` was received
+  on 2026-09-02. PR, merge, `dev`, `main`, `upstream`, and Release actions remain
+  out of scope.
+
+---
+
 # Hotbar OFF mouse-selection follow-up — 2026-09-02
 
 Target: fix only the reproducible `Use Numbers for Hotbar = OFF` selection

--- a/TESTING.md
+++ b/TESTING.md
@@ -126,6 +126,23 @@ Use only disposable test credentials and remove them afterward.
    must return to fallback handling before OCR capture, and watchdog cleanup
    must not crash.
 
+### Watchdog PID lifecycle
+
+1. With TimeScale OFF, start a normal strategy and stop it. Repeat at least
+   three times and confirm there is no `VarUnset` dialog and at most one
+   watchdog process for this checkout remains while the strategy is running.
+2. Repeat with TimeScale 2x. Exercise Restart, Play Again, and reconnect paths
+   where practical; these transitions must not change TimeScale behavior or
+   accumulate watchdog processes.
+3. Close Main while a strategy is active. Confirm its watchdog exits and that a
+   watchdog launched from a different checkout or extracted release is not
+   terminated.
+4. Inspect `%APPDATA%\Ultimate_Macro\Logs\ultimate-macro.log`. Normal cycles
+   should show `watchdog_started` and `watchdog_stopped`. Capture any
+   `watchdog_start_failed`, `watchdog_cleanup_failed`,
+   `watchdog_cleanup_scan_failed`, or `watchdog_exit_cleanup_failed` event with
+   its details if a failure occurs.
+
 ### Transactional updater
 
 Use a disposable extracted release copy, never this Git checkout.

--- a/tests/test_reported_runtime_fixes.py
+++ b/tests/test_reported_runtime_fixes.py
@@ -324,6 +324,59 @@ def validate_dj_watchdog_and_pr30(main: str, watchdog: str) -> None:
             "Arcade search bounds must pass width/height, not bottom-right coordinates")
 
 
+def validate_watchdog_pid_lifecycle(main: str) -> None:
+    start = region(main, "startWatchdog() {", "KillSubmacros() {")
+    cleanup = region(main, "KillSubmacros() {", "HandleExit(ExitReason, ExitCode) {")
+    handle_exit = region(main, "HandleExit(ExitReason, ExitCode) {", "CleanupGdip(exitReason, exitCode) {")
+
+    require('global watchdogPID := ""' in main,
+            "watchdog PID must retain an explicit startup initializer")
+    require("newWatchdogPID := 0" in start and "&newWatchdogPID" in start,
+            "watchdog launch must use an initialized local output PID")
+    require("&watchdogPID" not in start,
+            "Run must not mutate the shared watchdog PID directly")
+    run_index = start.find("Run(command, , , &newWatchdogPID)")
+    publish_index = start.find("watchdogPID := newWatchdogPID")
+    require(0 <= run_index < publish_index,
+            "the shared watchdog PID must be published only after Run succeeds")
+    require('RuntimeLogInfo("watchdog_started"' in start,
+            "successful watchdog launches must be diagnosable")
+    require('watchdogPID := ""' in start and
+            'RuntimeLogError("watchdog_start_failed"' in start and
+            "return false" in start,
+            "failed watchdog launches must restore a known idle state")
+
+    require('if (IsSet(watchdogPID) && watchdogPID != "")' in cleanup,
+            "cleanup must guard the shared PID before reading it")
+    clear_index = cleanup.find('watchdogPID := ""')
+    tracked_index = cleanup.find('if (trackedPID != "")')
+    require(0 <= clear_index < tracked_index,
+            "cleanup must publish the idle state before process operations")
+    require('if (watchdogPID != "")' not in cleanup,
+            "cleanup must not contain an unguarded shared PID read")
+    require(r'A_ScriptDir "\submacros\watchdog.ahk"' in cleanup and
+            "InStr(normalizedCmd, targetScript)" in cleanup,
+            "fallback cleanup must remain scoped to this checkout's watchdog path")
+    for event in ("watchdog_stopped", "watchdog_cleanup_failed", "watchdog_cleanup_scan_failed"):
+        require(event in cleanup, f"cleanup diagnostic is missing: {event}")
+
+    require("global StateFile, SettingsFile, RunningStrategy" in handle_exit,
+            "OnExit must explicitly bind its running-state global")
+    require("try KillSubmacros()" in handle_exit,
+            "OnExit must attempt watchdog cleanup independently of strategy state")
+    require("if (IsSet(RunningStrategy) && RunningStrategy)" in handle_exit,
+            "OnExit must tolerate the startup initialization window")
+    require("if (RunningStrategy)" not in handle_exit,
+            "OnExit must not read an uninitialized running state")
+    require("watchdog_exit_cleanup_failed" in handle_exit,
+            "OnExit cleanup failures must be diagnosable")
+
+    require("KillSubmacros()" in start,
+            "watchdog launch must clean up a prior instance first")
+    require("KillSubmacros()\n    startWatchdog()" in main,
+            "the real repeated cleanup/start lifecycle must remain covered")
+
+
 def validate_packaging(root: Path, validator: str, workflow: str) -> None:
     obsolete = {
         "Resources/Strats/2_Absolute_Zero.strat",
@@ -413,6 +466,7 @@ def main() -> int:
     validate_matchmaking_ready_map(main_source, validator)
     validate_paths(main_source)
     validate_dj_watchdog_and_pr30(main_source, watchdog_source)
+    validate_watchdog_pid_lifecycle(main_source)
     validate_community_strategy_sync(main_source)
     validate_packaging(root, validator, workflow)
 

--- a/tests/test_source_contracts.py
+++ b/tests/test_source_contracts.py
@@ -193,6 +193,31 @@ def validate_watchdog_retry_lifecycle(watchdog: str) -> None:
     assert "return true" in send and "return false" in send
 
 
+def validate_watchdog_pid_lifecycle(main: str) -> None:
+    start = region(main, "startWatchdog() {", "KillSubmacros() {")
+    cleanup = region(main, "KillSubmacros() {", "HandleExit(ExitReason, ExitCode) {")
+    handle_exit = region(main, "HandleExit(ExitReason, ExitCode) {", "CleanupGdip(exitReason, exitCode) {")
+
+    assert "newWatchdogPID := 0" in start
+    assert "&newWatchdogPID" in start
+    assert "&watchdogPID" not in start
+    assert start.index("Run(command, , , &newWatchdogPID)") < start.index(
+        "watchdogPID := newWatchdogPID"
+    )
+    assert "watchdog_start_failed" in start and "return false" in start
+
+    assert 'if (IsSet(watchdogPID) && watchdogPID != "")' in cleanup
+    assert cleanup.index('watchdogPID := ""') < cleanup.index('if (trackedPID != "")')
+    assert 'if (watchdogPID != "")' not in cleanup
+    assert r'A_ScriptDir "\submacros\watchdog.ahk"' in cleanup
+    assert "InStr(normalizedCmd, targetScript)" in cleanup
+
+    assert "try KillSubmacros()" in handle_exit
+    assert "if (IsSet(RunningStrategy) && RunningStrategy)" in handle_exit
+    assert "if (RunningStrategy)" not in handle_exit
+    assert "watchdog_exit_cleanup_failed" in handle_exit
+
+
 def validate_ready_detection(main: str) -> None:
     ready = region(main, "FindReadyButton(&foundX, &foundY)", "activateTimescale()")
     template_index = ready.find('AdvancedImageSearch("Resources/ready_gs.png"')
@@ -401,6 +426,7 @@ def validate(root: Path) -> None:
     validate_watchdog_result_fallbacks(watchdog)
     validate_watchdog_conditions_and_formatting(watchdog)
     validate_watchdog_retry_lifecycle(watchdog)
+    validate_watchdog_pid_lifecycle(main)
     validate_roblox_coordinates(roblox)
     validate_ready_detection(main)
     validate_community_strategy_update(main)


### PR DESCRIPTION
Launch the watchdog through an initialized local PID and publish it only after success. Make repeated cleanup and early OnExit handling idempotent while preserving path-scoped process isolation and adding structured diagnostics.

Tests: full Python contracts and validators, strategy lint, PowerShell validation, updater smoke test, and AutoHotkey 2.0.12/2.0.26 validation pass. Manual Roblox QA passes TimeScale OFF and 2x.

Risk: limited to watchdog lifecycle handling; rollback by reverting this commit.
