### PR TITLE
Strategy tabs, and other strat features

### DIFF
--- a/Main.ahk
+++ b/Main.ahk
@@ -912,8 +912,18 @@ global AutoConfigCtrl := MainGui.Add("Checkbox", "x490 y190 vAutoConfigureSettin
 AutoConfigCtrl.OnEvent("Click", EnableAutoConfig)
 
 MainGui.SetFont("s10 w400 c3A86FF", UIFont())
-global Tab1_Section2 := MainGui.Add("Text", "x30 y225 h22", "Community Strategies")
+global Tab1_Section2 := MainGui.Add("Text", "x30 y225 h22", "Strategies")
 global Tab1_Line2 := MainGui.Add("Progress", "x30 y248 w640 h1 Background333333", 0)
+
+MainGui.SetFont("s10 w400 c3A86FF", UIFont())
+global BtnCommStrats := MainGui.Add("Text", "x30 y257 w120 h24 Center Background222222 +Border 0x200", "Community")
+MainGui.SetFont("s10 w400 cFFFFFF", UIFont())
+global BtnMyStrats := MainGui.Add("Text", "x160 y257 w120 h24 Center Background0e0e0f +Border 0x200", "My Strats")
+
+BtnCommStrats.OnEvent("Click", (*) => SwitchStrategiesTab("Community"))
+BtnMyStrats.OnEvent("Click", (*) => SwitchStrategiesTab("MyStrats"))
+HoverEffect.Push(BtnCommStrats)
+HoverEffect.Push(BtnMyStrats)
 
 if !DirExist(StratsDir)
     DirCreate(StratsDir)
@@ -1088,208 +1098,358 @@ if (needUpdate) {
 }
 
 global FrameX := 30
-global FrameY := 260
+global FrameY := 290
 global FrameW := 640
-global FrameH := 220
+global FrameH := 190
 global ContentH := 400
 global CurrentScrollPos := 0
 global ScrollDragging := false
 global ScrollDragGrab := 0
 global SliderH := 30
+global SliderX := 0
+global SliderW := 0
 global ChildHwnd := 0
+global ChildGui := ""
+global ContentGui := ""
 
-ChildGui := Gui("-Caption +E0x20 +Border +Parent" MainGui.Hwnd)
-ChildGui.BackColor := "181818"
-ChildGui.SetFont("s10 cWhite", UIFont())
-width := FrameW - 6
+global IsRenderingStrategies := false
+global RenderedBitmaps := []
 
-loop files, StratsDir "\*.strat" {
-    localPath := A_LoopFileFullPath
-
-    sMap := IniRead(localPath, "Settings", "map", "")
-    sDifficulty := IniRead(localPath, "Settings", "difficulty", "")
-    sTowers := IniRead(localPath, "Settings", "requiredTowers", "")
-    sDesc := IniRead(localPath, "Info", "desc", "")
-    sAuthor := IniRead(localPath, "Info", "author", "")
-    sTitle := IniRead(localPath, "Info", "title", "")
-    sTime := IniRead(localPath, "Info", "time", "")
-    sIncome := IniRead(localPath, "Info", "income", "")
-    sModifiers := IniRead(localPath, "Settings", "modifiers", "")
-
-    LoadedStrats.Push({
-        fileName: A_LoopFileName,
-        map: sMap,
-        difficulty: sDifficulty,
-        towers: sTowers,
-        desc: sDesc,
-        author: sAuthor,
-        title: sTitle,
-        time: sTime,
-        income: sIncome,
-        modifiers: sModifiers
-    })
-}
-
-StartY := 15
-CardH := 115
-CardW := 600
-Gap := 15
-
-ContentH := StartY
-
-for index, strat in LoadedStrats {
-    CurrentY := StartY + ((index - 1) * (CardH + Gap))
-    ContentH := CurrentY + CardH + Gap
-
-    C1X := 10
-    C1Y := CurrentY
-
-    hFrameBg := CreateFrame(CardW, CardH, 10, "0xff161616", "0xff1d1d1d", "0x62302d2d")
-    ChildGui.Add("Picture", "x" C1X " y" C1Y " w" CardW " h" CardH " +BackgroundTrans", "HBITMAP:*" hFrameBg)
-
-    hIconBg := CreateGradientButton(56, 56, 8, "0xff2f353f", "0xff15171b", "0xff000000", "0x232c3a50", "", UIFont(),
-        10, 1)
-    ChildGui.Add("Picture", "x" (C1X + 10) " y" (C1Y + 30) " w76 h76 +BackgroundTrans", "HBITMAP:*" hIconBg)
-
-    diffImg := "Resources/Strats/images/" strat.difficulty ".png"
-    if !FileExist(diffImg) {
-        LogToConsole("Missing resource file: " diffImg)
-    } else {
-        ChildGui.Add("Picture", "x" (C1X + 20) " y" (C1Y + 40) " h56 w56 +BackgroundTrans", diffImg)
-    }
-
-    ChildGui.Add("Picture", "x" (C1X + 75) " y" (C1Y + 30) " w76 h76 +BackgroundTrans", "HBITMAP:*" hIconBg)
-
-    coinsCount := 0
-    if RegExMatch(strat.income, "i)([\d,]+)\s*coins", &match) {
-        coinsCount := Number(StrReplace(match[1], ","))
-    }
-
-    if (strat.difficulty = "Hardcore" || strat.difficulty = "Voidcore") {
-        rewardIcon := "Resources/Strats/images/GemsMediumPile.png"
-    } else {
-        if (coinsCount >= 8000) {
-            rewardIcon := "Resources/Strats/images/CoinsSmallChest.png"
-        } else if (coinsCount >= 6000) {
-            rewardIcon := "Resources/Strats/images/CoinsMediumPile.png"
-        } else {
-            rewardIcon := "Resources/Strats/images/CoinsSmallPile.png"
+DisposeBitmap(hBitmap) {
+    if (hBitmap) {
+        try {
+            DeleteObject(hBitmap)
+        } catch Error as e {
         }
     }
-
-    if !FileExist(rewardIcon) {
-        LogToConsole("Missing resource file: " rewardIcon)
-    } else {
-        ChildGui.Add("Picture", "x" (C1X + 85) " y" (C1Y + 40) " h56 w56 +BackgroundTrans", rewardIcon)
-    }
-
-    ChildGui.SetFont("s11 Bold cWhite", UIFont())
-    ChildGui.Add("Text", "x" (C1X + 15) " y" (C1Y + 12) " +BackgroundTrans", strat.title != "" ? strat.title :
-        "Unknown Strat")
-
-    ChildGui.SetFont("s9 w500 c7E848E", UIFont())
-    helpDl1 := ChildGui.Add("Text", "x" (C1X + 580) " y" (C1Y + 10) " +BackgroundTrans", "?")
-    helpDl1.OnEvent("Click", ((t, a, r, m, d) => (*) => StratInfo(t, a, r, m, d))(
-        strat.title,
-        strat.author,
-        strat.towers,
-        (strat.modifiers != "" ? strat.modifiers : "none"),
-        strat.desc
-    ))
-
-    ChildGui.SetFont("s9 w400 cE2E4E7", UIFont())
-    ChildGui.Add("Text", "x" (C1X + 260) " y" (C1Y + 15) " w340 +BackgroundTrans", (strat.towers != "" ? strat.towers :
-        "None"))
-
-    ChildGui.SetFont("s9 w400 c7E848E", UIFont())
-    ChildGui.Add("Text", "x" (C1X + 260) " y" (C1Y + 36) " w320 +BackgroundTrans", strat.desc)
-
-    if (strat.difficulty = "Hardcore") {
-        badgeColor1 := "0xFFAB457B", badgeColor2 := "0xFF5C2040"
-    } else if (strat.difficulty = "Molten") {
-        badgeColor1 := "0xFFE09334", badgeColor2 := "0xFF8F5413"
-    } else if (strat.difficulty = "Frost") {
-        badgeColor1 := "0xff34a9e0", badgeColor2 := "0xff17559c"
-    } else if (strat.difficulty = "Fallen") {
-        badgeColor1 := "0xff17559c", badgeColor2 := "0xff351570"
-    } else {
-        badgeColor1 := "0xb900ff2a", badgeColor2 := "0xff1a5f39"
-    }
-
-    hgmMode := CreateGradientButton(102, 28, 3, badgeColor1, badgeColor2, "0x40000000", "0x7effffff", strat.difficulty !=
-        "" ? strat.difficulty : "Easy", UIFont(), 11, 1)
-    ChildGui.Add("Picture", "x" (C1X + 145) " y" (C1Y + 35) " w102 h28 +BackgroundTrans", "HBITMAP:*" hgmMode)
-
-    ChildGui.SetFont("s9 w500 c9CA4B0", UIFont())
-    ChildGui.Add("Text", "x" (C1X + 155) " y" (C1Y + 65) " +BackgroundTrans", "🕒 " (strat.time != "" ? strat.time :
-        "Unknown"))
-    ChildGui.Add("Text", "x" (C1X + 155) " y" (C1Y + 83) " +BackgroundTrans", "⛃ " (strat.income != "" ? strat.income :
-        "Unknown"))
-
-    if ((strat.difficulty = "Hardcore" || strat.difficulty = "Voidcore")) {
-        hBtnNormal := CreateGradientButton(220, 38, 8, "0xff961ea1", "0xff5f237a", "0x40000000", "0x5dffffff", "Load",
-            UIFont(), 14, 1)
-        hBtnHover := CreateGradientButton(220, 38, 8, "0xffea00ff", "0xff8d32b7", "0x60000000", "0x5dffffff", "Load",
-            UIFont(), 14, 1)
-    } else {
-        hBtnNormal := CreateGradientButton(220, 38, 8, "0xFF147A6E", "0xFF214B75", "0x40000000", "0x5dffffff", "Load",
-            UIFont(), 14, 1)
-        hBtnHover := CreateGradientButton(220, 38, 8, "0xFF1CB5A2", "0xFF3272B7", "0x60000000", "0x5dffffff", "Load",
-            UIFont(), 14, 1)
-    }
-
-    picLoadBtn := ChildGui.Add("Picture", "x" (C1X + 365) " y" (C1Y + 68) " w220 h38 +BackgroundTrans", "HBITMAP:*" hBtnNormal
-    )
-
-    dl1 := ChildGui.Add("Text", "x" (C1X + 365) " y" (C1Y + 68) " w220 h38 +BackgroundTrans +0x200 Center", "")
-    dl1.SetFont("cFFFFFF s10 Bold", UIFont())
-
-    dl1.StratFile := strat.fileName
-    dl1.OnEvent("Click", DownloadStrat)
-
-    dl1.PicControl := picLoadBtn
-    dl1.ImgNormal := hBtnNormal
-    dl1.ImgHover := hBtnHover
-    GradientButtons.Push(dl1)
 }
 
-if (LoadedStrats.Length == 0) {
-    ChildGui.SetFont("s12 c7E848E", UIFont())
-    ChildGui.Add("Text", "x0 y0 w" FrameW " h" FrameH " +BackgroundTrans Center +0x200", "No strategies found.")
-    ContentH := 220
+CleanupRenderedBitmaps() {
+    global RenderedBitmaps
+    for index, hBitmap in RenderedBitmaps {
+        DisposeBitmap(hBitmap)
+    }
+    RenderedBitmaps := []
 }
 
-SliderX := FrameW - 10
-SliderW := 6
+global CurrentStratTabMode := ""
 
-if (ContentH > 0) {
-    SliderH := Round(FrameH * (FrameH / ContentH))
-
-    if (ContentH <= FrameH) {
-        SliderH := FrameH
+SwitchStrategiesTab(mode) {
+    global BtnCommStrats, BtnMyStrats, IsRenderingStrategies, CurrentStratTabMode
+    
+    ; If the user clicks the tab that is already selected, do nothing.
+    if (CurrentStratTabMode == mode)
+        return
+        
+    if (IsRenderingStrategies)
+        return
+        
+    IsRenderingStrategies := true
+    CurrentStratTabMode := mode
+    
+    CleanupRenderedBitmaps()
+    
+    if (mode == "Community") {
+        BtnCommStrats.IsSelected := true
+        BtnMyStrats.IsSelected := false
+        
+        BtnCommStrats.Opt("Background222222")
+        BtnCommStrats.SetFont("c3A86FF Bold")
+        BtnMyStrats.Opt("Background0e0e0f")
+        BtnMyStrats.SetFont("cFFFFFF Norm")
     } else {
-        SliderH := Max(30, SliderH)
+        BtnCommStrats.IsSelected := false
+        BtnMyStrats.IsSelected := true
+        
+        BtnMyStrats.Opt("Background222222")
+        BtnMyStrats.SetFont("c3A86FF Bold")
+        BtnCommStrats.Opt("Background0e0e0f")
+        BtnCommStrats.SetFont("cFFFFFF Norm")
+    }
+    
+    BtnCommStrats.Redraw()
+    BtnMyStrats.Redraw()
+    
+    RenderStrategies(mode)
+    
+    IsRenderingStrategies := false
+}
+
+RenderStrategies(mode := "Community") {
+    global ChildGui, ContentGui, MainGui, LoadedStrats, GradientButtons
+    global FrameX, FrameY, FrameW, FrameH, ContentH, CurrentScrollPos, SliderH, SliderBG, Slider
+    global StratsDir, RecordingsDir, CurrentTab, ChildHwnd, RenderedBitmaps, SliderX, SliderW
+    global Strategy1Path, Strategy2Path, RotateStrategies
+
+    CleanupRenderedBitmaps()
+    
+    newGradBtns := []
+    if IsSet(GradientButtons) {
+        for btn in GradientButtons {
+            if !HasProp(btn, "StratFile")
+                newGradBtns.Push(btn)
+        }
+    }
+    GradientButtons := newGradBtns
+
+    if (!IsSet(ChildGui) || ChildGui == "") {
+        ChildGui := Gui("-Caption +E0x20 +Border +Parent" MainGui.Hwnd)
+        ChildGui.BackColor := "181818"
+        ChildGui.SetFont("s10 cWhite", UIFont())
+        ChildHwnd := ChildGui.Hwnd
     }
 
-    if (ContentH > FrameH && CurrentScrollPos > 0) {
-        maxScroll := ContentH - FrameH
-        scrollPercent := CurrentScrollPos / maxScroll
-        sliderPos := Round(scrollPercent * (FrameH - SliderH))
-        sliderPos := Max(0, Min(sliderPos, FrameH - SliderH))
-    } else {
+    if (IsSet(ContentGui) && ContentGui != "") {
+        try ContentGui.Destroy()
+        catch
+        ContentGui := ""
+    }
+
+    ContentGui := Gui("-Caption +Parent" ChildGui.Hwnd)
+    ContentGui.BackColor := "181818"
+    ContentGui.SetFont("s10 cWhite", UIFont())
+    width := FrameW - 6
+
+    LoadedStrats := []
+    CurrentScrollPos := 0
+
+    targetDir := (mode == "Community") ? StratsDir : RecordingsDir
+
+    loop files, targetDir "\*.strat" {
+        localPath := A_LoopFileFullPath
+
+        sMap := IniRead(localPath, "Settings", "map", "Unknown")
+        sDifficulty := IniRead(localPath, "Settings", "difficulty", "Easy")
+        sTowers := IniRead(localPath, "Settings", "requiredTowers", "None")
+        sDesc := IniRead(localPath, "Info", "desc", "Local recording.")
+        sAuthor := IniRead(localPath, "Info", "author", "You")
+        sTitle := IniRead(localPath, "Info", "title", StrReplace(A_LoopFileName, ".strat", ""))
+        sTime := IniRead(localPath, "Info", "time", "N/A")
+        sIncome := IniRead(localPath, "Info", "income", "N/A")
+        sModifiers := IniRead(localPath, "Settings", "modifiers", "")
+
+        LoadedStrats.Push({
+            fileName: A_LoopFileName,
+            map: sMap,
+            difficulty: sDifficulty,
+            towers: sTowers,
+            desc: sDesc,
+            author: sAuthor,
+            title: sTitle,
+            time: sTime,
+            income: sIncome,
+            modifiers: sModifiers,
+            fullPath: localPath
+        })
+    }
+
+    StartY := 15
+    CardH := 115
+    CardW := 600
+    Gap := 15
+
+    ContentH := StartY
+
+    for index, strat in LoadedStrats {
+        CurrentY := StartY + ((index - 1) * (CardH + Gap))
+        ContentH := CurrentY + CardH + Gap
+
+        C1X := 10
+        C1Y := CurrentY
+
+        hFrameBg := CreateFrame(CardW, CardH, 10, "0xff161616", "0xff1d1d1d", "0x62302d2d")
+        RenderedBitmaps.Push(hFrameBg)
+        ContentGui.Add("Picture", "x" C1X " y" C1Y " w" CardW " h" CardH " +BackgroundTrans", "HBITMAP:*" hFrameBg)
+
+        hIconBg := CreateGradientButton(56, 56, 8, "0xff2f353f", "0xff15171b", "0xff000000", "0x232c3a50", "", UIFont(), 10, 1)
+        RenderedBitmaps.Push(hIconBg)
+        ContentGui.Add("Picture", "x" (C1X + 10) " y" (C1Y + 30) " w76 h76 +BackgroundTrans", "HBITMAP:*" hIconBg)
+        
+        hIconBg2 := CreateGradientButton(56, 56, 8, "0xff2f353f", "0xff15171b", "0xff000000", "0x232c3a50", "", UIFont(), 10, 1)
+        RenderedBitmaps.Push(hIconBg2)
+        ContentGui.Add("Picture", "x" (C1X + 75) " y" (C1Y + 30) " w76 h76 +BackgroundTrans", "HBITMAP:*" hIconBg2)
+
+        diffImg := "Resources/Strats/images/" strat.difficulty ".png"
+        if !FileExist(diffImg) {
+            LogToConsole("Missing resource file: " diffImg)
+        } else {
+            ContentGui.Add("Picture", "x" (C1X + 20) " y" (C1Y + 40) " h56 w56 +BackgroundTrans", diffImg)
+        }
+
+        coinsCount := 0
+        if RegExMatch(strat.income, "i)([\d,]+)\s*coins", &match) {
+            coinsCount := Number(StrReplace(match[1], ","))
+        }
+
+        if (strat.difficulty = "Hardcore" || strat.difficulty = "Voidcore") {
+            rewardIcon := "Resources/Strats/images/GemsMediumPile.png"
+        } else {
+            if (coinsCount >= 8000) {
+                rewardIcon := "Resources/Strats/images/CoinsSmallChest.png"
+            } else if (coinsCount >= 6000) {
+                rewardIcon := "Resources/Strats/images/CoinsMediumPile.png"
+            } else {
+                rewardIcon := "Resources/Strats/images/CoinsSmallPile.png"
+            }
+        }
+
+        if !FileExist(rewardIcon) {
+            LogToConsole("Missing resource file: " rewardIcon)
+        } else {
+            ContentGui.Add("Picture", "x" (C1X + 85) " y" (C1Y + 40) " h56 w56 +BackgroundTrans", rewardIcon)
+        }
+
+        ContentGui.SetFont("s11 Bold cWhite", UIFont())
+        ContentGui.Add("Text", "x" (C1X + 15) " y" (C1Y + 12) " +BackgroundTrans", strat.title != "" ? strat.title : "Unknown Strat")
+
+        ContentGui.SetFont("s9 w500 c7E848E", UIFont())
+        helpDl1 := ContentGui.Add("Text", "x" (C1X + 580) " y" (C1Y + 10) " +BackgroundTrans", "?")
+        helpDl1.OnEvent("Click", ((t, a, r, m, d) => (*) => StratInfo(t, a, r, m, d))(
+            strat.title,
+            strat.author,
+            strat.towers,
+            (strat.modifiers != "" ? strat.modifiers : "none"),
+            strat.desc
+        ))
+
+        ContentGui.SetFont("s9 w400 cE2E4E7", UIFont())
+        ContentGui.Add("Text", "x" (C1X + 260) " y" (C1Y + 15) " w340 +BackgroundTrans", (strat.towers != "" ? strat.towers : "None"))
+
+        ContentGui.SetFont("s9 w400 c7E848E", UIFont())
+        ContentGui.Add("Text", "x" (C1X + 260) " y" (C1Y + 36) " w320 +BackgroundTrans", strat.desc)
+
+        if (strat.difficulty = "Hardcore") {
+            badgeColor1 := "0xFFAB457B", badgeColor2 := "0xFF5C2040"
+        } else if (strat.difficulty = "Molten") {
+            badgeColor1 := "0xFFE09334", badgeColor2 := "0xFF8F5413"
+        } else if (strat.difficulty = "Frost") {
+            badgeColor1 := "0xff34a9e0", badgeColor2 := "0xff17559c"
+        } else if (strat.difficulty = "Fallen") {
+            badgeColor1 := "0xff17559c", badgeColor2 := "0xff351570"
+        } else {
+            badgeColor1 := "0xb900ff2a", badgeColor2 := "0xff1a5f39"
+        }
+
+        hgmMode := CreateGradientButton(102, 28, 3, badgeColor1, badgeColor2, "0x40000000", "0x7effffff", strat.difficulty != "" ? strat.difficulty : "Easy", UIFont(), 11, 1)
+        RenderedBitmaps.Push(hgmMode)
+        ContentGui.Add("Picture", "x" (C1X + 145) " y" (C1Y + 35) " w102 h28 +BackgroundTrans", "HBITMAP:*" hgmMode)
+
+        ContentGui.SetFont("s9 w500 c9CA4B0", UIFont())
+        ContentGui.Add("Text", "x" (C1X + 155) " y" (C1Y + 65) " +BackgroundTrans", "🕒 " (strat.time != "" ? strat.time : "Unknown"))
+        ContentGui.Add("Text", "x" (C1X + 155) " y" (C1Y + 83) " +BackgroundTrans", "⛃ " (strat.income != "" ? strat.income : "Unknown"))
+
+        isLoaded := false
+        if (Strategy1Path != "" && StrLower(strat.fullPath) == StrLower(Strategy1Path))
+            isLoaded := true
+        else if (Strategy2Path != "" && RotateStrategies && StrLower(strat.fullPath) == StrLower(Strategy2Path))
+            isLoaded := true
+
+        btnText := isLoaded ? "Currently Loaded" : "Load"
+
+        if (isLoaded) {
+            loadColor1 := "0xFF4b5563", loadColor2 := "0xFF374151"
+            loadHover1 := "0xFF505A69", loadHover2 := "0xFF3A4557"
+        } else if ((strat.difficulty = "Hardcore" || strat.difficulty = "Voidcore")) {
+            loadColor1 := "0xff961ea1", loadColor2 := "0xff5f237a"
+            loadHover1 := "0xffea00ff", loadHover2 := "0xff8d32b7"
+        } else {
+            loadColor1 := "0xFF147A6E", loadColor2 := "0xFF214B75"
+            loadHover1 := "0xFF1CB5A2", loadHover2 := "0xFF3272B7"
+        }
+
+        if (mode == "MyStrats") {
+            hBtnNormal := CreateGradientButton(145, 38, 8, loadColor1, loadColor2, "0x40000000", "0x5dffffff", btnText, UIFont(), isLoaded ? 11 : 14, 1)
+            RenderedBitmaps.Push(hBtnNormal)
+            hBtnHover := CreateGradientButton(145, 38, 8, loadHover1, loadHover2, "0x60000000", "0x5dffffff", btnText, UIFont(), isLoaded ? 11 : 14, 1)
+            RenderedBitmaps.Push(hBtnHover)
+            
+            editColor1 := "0xFF4b5563", editColor2 := "0xFF374151"
+            editHover1 := "0xFF6b7280", editHover2 := "0xFF4b5563"
+            hEditNormal := CreateGradientButton(70, 38, 8, editColor1, editColor2, "0x40000000", "0x5dffffff", "Edit", UIFont(), 12, 1)
+            RenderedBitmaps.Push(hEditNormal)
+            hEditHover := CreateGradientButton(70, 38, 8, editHover1, editHover2, "0x60000000", "0x5dffffff", "Edit", UIFont(), 12, 1)
+            RenderedBitmaps.Push(hEditHover)
+
+            picLoadBtn := ContentGui.Add("Picture", "x" (C1X + 365) " y" (C1Y + 68) " w145 h38 +BackgroundTrans", "HBITMAP:*" hBtnNormal)
+            dl1 := ContentGui.Add("Text", "x" (C1X + 365) " y" (C1Y + 68) " w145 h38 +BackgroundTrans +0x200 Center", "")
+            
+            picEditBtn := ContentGui.Add("Picture", "x" (C1X + 515) " y" (C1Y + 68) " w70 h38 +BackgroundTrans", "HBITMAP:*" hEditNormal)
+            dlEdit := ContentGui.Add("Text", "x" (C1X + 515) " y" (C1Y + 68) " w70 h38 +BackgroundTrans +0x200 Center", "")
+            
+            dlEdit.SetFont("cFFFFFF s10 Bold", UIFont())
+            dlEdit.StratFile := strat.fullPath
+            dlEdit.OnEvent("Click", EditStratFile)
+            dlEdit.PicControl := picEditBtn
+            dlEdit.ImgNormal := hEditNormal
+            dlEdit.ImgHover := hEditHover
+            dlEdit.GradEnabled := true
+            GradientButtons.Push(dlEdit)
+        } else {
+            hBtnNormal := CreateGradientButton(220, 38, 8, loadColor1, loadColor2, "0x40000000", "0x5dffffff", btnText, UIFont(), isLoaded ? 12 : 14, 1)
+            RenderedBitmaps.Push(hBtnNormal)
+            hBtnHover := CreateGradientButton(220, 38, 8, loadHover1, loadHover2, "0x60000000", "0x5dffffff", btnText, UIFont(), isLoaded ? 12 : 14, 1)
+            RenderedBitmaps.Push(hBtnHover)
+            
+            picLoadBtn := ContentGui.Add("Picture", "x" (C1X + 365) " y" (C1Y + 68) " w220 h38 +BackgroundTrans", "HBITMAP:*" hBtnNormal)
+            dl1 := ContentGui.Add("Text", "x" (C1X + 365) " y" (C1Y + 68) " w220 h38 +BackgroundTrans +0x200 Center", "")
+        }
+
+        dl1.SetFont("cFFFFFF s10 Bold", UIFont())
+        dl1.StratFile := strat.fullPath
+        dl1.StratDiff := strat.difficulty
+        dl1.IsSmallBtn := (mode == "MyStrats")
+        
+        dl1.OnEvent("Click", DownloadStrat)
+        dl1.ImgHover := isLoaded ? hBtnNormal : hBtnHover
+        
+        dl1.PicControl := picLoadBtn
+        dl1.ImgNormal := hBtnNormal
+        dl1.GradEnabled := true
+        GradientButtons.Push(dl1)
+    }
+
+    if (LoadedStrats.Length == 0) {
+        ContentGui.SetFont("s12 c7E848E", UIFont())
+        ContentGui.Add("Text", "x0 y0 w" FrameW " h" FrameH " +BackgroundTrans Center +0x200", "No strategies found.")
+        ContentH := FrameH
+    }
+
+    SliderX := FrameW - 10
+    SliderW := 6
+
+    if (ContentH > 0) {
+        SliderH := Round(FrameH * (FrameH / ContentH))
+
+        if (ContentH <= FrameH) {
+            SliderH := FrameH
+        } else {
+            SliderH := Max(30, SliderH)
+        }
+
         sliderPos := 0
+
+        hSlider := CreateScrollThumb(SliderW, SliderH, 3, "0xFF6EA7FF", "0xff4076ce", "0xd4d4d4")
+        RenderedBitmaps.Push(hSlider)
+        hSliderBG := CreateScrollThumb(SliderW, FrameH, 3, "0xff000000", "0xff000000", "0x000000")
+        RenderedBitmaps.Push(hSliderBG)
+
+        SliderBG := ContentGui.Add("Picture", "x" SliderX " y0 w" SliderW " h" (ContentH <= FrameH ? FrameH : FrameH + ContentH) " +BackgroundTrans +0x0100", "HBITMAP:*" hSliderBG)
+        Slider := ContentGui.Add("Picture", "x" SliderX " y" sliderPos " w" SliderW " h" SliderH " +BackgroundTrans +0x0100", "HBITMAP:*" hSlider)
+
+        if (ContentH <= FrameH) {
+            SliderBG.Visible := false
+            Slider.Visible := false
+        } else {
+            SliderBG.Visible := true
+            Slider.Visible := true
+        }
     }
-
-    hSlider := CreateScrollThumb(SliderW, SliderH, 3, "0xFF6EA7FF", "0xff4076ce", "0xd4d4d4")
-    hSliderBG := CreateScrollThumb(SliderW, FrameH, 3, "0xff000000", "0xff000000", "0x000000")
-
-    global SliderBG := ChildGui.Add("Picture", "x" SliderX " y0 w" SliderW " h" FrameH + ContentH " +BackgroundTrans",
-        "HBITMAP:*" hSliderBG)
-    global Slider := ChildGui.Add("Picture", "x" SliderX " y" sliderPos " w" SliderW " h" SliderH " +BackgroundTrans",
-        "HBITMAP:*" hSlider)
-
-    SliderBG.Visible := true
-    Slider.Visible := true
+    
+    ContentGui.Show("x0 y0 w" FrameW " h" FrameH)
+    
+    if (CurrentTab == "Tab1") {
+        ShowChildGui()
+    }
 }
 
 OnMessage(0x0115, OnScroll)
@@ -1812,8 +1972,8 @@ SetTimer(() => RemoveInitialFocus(), -50)
 
 global CurrentTab := "Tab1"
 TabCtrl[1].SetFont("cFFFFFF")
+SwitchStrategiesTab("Community")
 ShowTabContent("Tab1")
-ShowChildGui()
 EnableStratRotation()
 
 ; 10ms was 100 sweeps/second of Win32 geometry calls for a purely cosmetic hover
@@ -1923,6 +2083,9 @@ Hoverwatchdog(*) {
                     if RegExMatch(ctrl.name, "i)Title") {
                         ctrl.Opt("BackgroundTrans")
                         ctrl.SetFont("c3A86FF Norm")
+                    } else if (HasProp(ctrl, "IsSelected") && ctrl.IsSelected) {
+                        ctrl.Opt("Background222222")
+                        ctrl.SetFont("c3A86FF Bold")
                     } else {
                         ctrl.Opt("Background0E0E0F")
                         ctrl.SetFont("cFFFFFF Norm")
@@ -2007,6 +2170,9 @@ Hoverwatchdog(*) {
                                 if RegExMatch(oldCtrl.name, "i)title") {
                                     oldCtrl.Opt("BackgroundTrans")
                                     oldCtrl.SetFont("c3A86FF Norm")
+                                } else if (HasProp(oldCtrl, "IsSelected") && oldCtrl.IsSelected) {
+                                    oldCtrl.Opt("Background222222")
+                                    oldCtrl.SetFont("c3A86FF Bold")
                                 } else {
                                     oldCtrl.Opt("Background0E0E0F")
                                     oldCtrl.SetFont("cFFFFFF Norm")
@@ -2030,6 +2196,9 @@ Hoverwatchdog(*) {
                     if RegExMatch(ctrl.name, "i)title") {
                         ctrl.Opt("BackgroundTrans")
                         ctrl.SetFont("c3A86FF Norm")
+                    } else if (HasProp(ctrl, "IsSelected") && ctrl.IsSelected) {
+                        ctrl.Opt("Background222222")
+                        ctrl.SetFont("c3A86FF Bold")
                     } else {
                         ctrl.Opt("Background0E0E0F")
                         ctrl.SetFont("cFFFFFF Norm")
@@ -2126,7 +2295,7 @@ ShowTabContent(tab) {
     if (tab = "Tab1") {
         for ctrl in [Tab1_Section1, Tab1_Line1, Tab1_Lbl1, Strategy1Ctrl, Tab1_Btn1, Tab1_Btn2,
             Tab1_Lbl2, Strategy2Ctrl, Tab1_Btn3, Tab1_Btn4, RotateStrategiesCtrl, AutoEquipCtrl, AutoConfigCtrl, Tab1_Section2,
-            Tab1_Line2,
+            Tab1_Line2, BtnCommStrats, BtnMyStrats,
             Tab1_Start, Tab1_Stop]
             ShowControl(ctrl)
         EnableStratRotation()
@@ -2238,10 +2407,73 @@ YouTubeLink(ctrl, *) {
     Run("https://www.youtube.com/@darksenn")
 }
 
+UpdateStrategyButtons() {
+    global GradientButtons, Strategy1Path, Strategy2Path, RotateStrategies, RenderedBitmaps
+
+    for ctrl in GradientButtons {
+        if !HasProp(ctrl, "StratFile") || !HasProp(ctrl, "StratDiff")
+            continue
+
+        isLoaded := false
+        if (Strategy1Path != "" && StrLower(ctrl.StratFile) == StrLower(Strategy1Path))
+            isLoaded := true
+        else if (Strategy2Path != "" && RotateStrategies && StrLower(ctrl.StratFile) == StrLower(Strategy2Path))
+            isLoaded := true
+
+        btnText := isLoaded ? "Currently Loaded" : "Load"
+
+        if (isLoaded) {
+            loadColor1 := "0xFF4b5563", loadColor2 := "0xFF374151"
+            loadHover1 := "0xFF505A69", loadHover2 := "0xFF3A4557"
+        } else if ((ctrl.StratDiff = "Hardcore" || ctrl.StratDiff = "Voidcore")) {
+            loadColor1 := "0xff961ea1", loadColor2 := "0xff5f237a"
+            loadHover1 := "0xffea00ff", loadHover2 := "0xff8d32b7"
+        } else {
+            loadColor1 := "0xFF147A6E", loadColor2 := "0xFF214B75"
+            loadHover1 := "0xFF1CB5A2", loadHover2 := "0xFF3272B7"
+        }
+
+        width := HasProp(ctrl, "IsSmallBtn") && ctrl.IsSmallBtn ? 145 : 220
+        
+        hBtnNormal := CreateGradientButton(width, 38, 8, loadColor1, loadColor2, "0x40000000", "0x5dffffff", btnText, UIFont(), isLoaded ? (width==145?10:12) : 14, 1)
+        hBtnHover := CreateGradientButton(width, 38, 8, loadHover1, loadHover2, "0x60000000", "0x5dffffff", btnText, UIFont(), isLoaded ? (width==145?10:12) : 14, 1)
+
+        ; Register the new bitmaps to be cleaned up when tabs change
+        RenderedBitmaps.Push(hBtnNormal)
+        if (!isLoaded)
+            RenderedBitmaps.Push(hBtnHover)
+
+        ; Dispose the old bitmaps
+        DisposeBitmap(ctrl.ImgNormal)
+        if (ctrl.ImgHover != ctrl.ImgNormal)
+            DisposeBitmap(ctrl.ImgHover)
+
+        ; Apply to UI instantly without a full page refresh
+        ctrl.ImgNormal := hBtnNormal
+        ctrl.ImgHover := isLoaded ? hBtnNormal : hBtnHover
+        ctrl.PicControl.Value := "HBITMAP:*" hBtnNormal
+    }
+}
+
 DownloadStrat(ctrl, *) {
+    global Strategy1Path, Strategy2Path, RotateStrategies
     nm := ctrl.StratFile
 
-    downloadedStrat := A_WorkingDir "\Resources\Strats" (SubStr(nm, 1, 1) = "\" ? nm : "\" nm)
+    if (RegExMatch(nm, "^[a-zA-Z]:\\")) {
+        downloadedStrat := nm
+    } else {
+        downloadedStrat := A_WorkingDir "\Resources\Strats" (SubStr(nm, 1, 1) = "\" ? nm : "\" nm)
+    }
+
+    ; Block the click if the strategy is already loaded
+    isAlreadyLoaded := false
+    if (Strategy1Path != "" && StrLower(downloadedStrat) == StrLower(Strategy1Path))
+        isAlreadyLoaded := true
+    else if (Strategy2Path != "" && RotateStrategies && StrLower(downloadedStrat) == StrLower(Strategy2Path))
+        isAlreadyLoaded := true
+
+    if (isAlreadyLoaded)
+        return
 
     if (Strategy1Ctrl.Value = "") {
         Strategy1Ctrl.Value := downloadedStrat
@@ -2258,20 +2490,32 @@ DownloadStrat(ctrl, *) {
     }
 
     LoadStrategyFile(downloadedStrat)
+    
+    ; Update button graphics seamlessly without refreshing/jumping
+    UpdateStrategyButtons()
+}
+
+EditStratFile(ctrl, *) {
+    stratToEdit := ctrl.StratFile
+    if FileExist(stratToEdit) {
+        Run("notepad.exe `"" stratToEdit "`"")
+    } else {
+        MsgBox("Strategy file not found!`n" stratToEdit, "Error", 0x10)
+    }
 }
 
 OnMouseWheel(wp, lp, msg, hwnd) {
-    global ChildHwnd, ChildGui
+    global ChildHwnd, ChildGui, ContentGui
     MouseGetPos(, , &maxH, &ctrlH, 2)
 
     parentH := (ctrlH != "") ? DllCall("GetParent", "Ptr", ctrlH, "Ptr") : 0
-    ch := ChildGui.Hwnd
+    ch := (IsSet(ChildGui) && ChildGui != "") ? ChildGui.Hwnd : 0
+    co := (IsSet(ContentGui) && ContentGui != "") ? ContentGui.Hwnd : 0
 
-    if (maxH = ch || ctrlH = ch || parentH = ch) {
+    if (ch && (maxH = ch || maxH = co || ctrlH = ch || ctrlH = co || parentH = ch || parentH = co)) {
 
         dir := ((wp >> 16) & 0xFFFF) > 0x7FFF ? 1 : 0
         loop 3 {
-
             SendMessage(0x0115, dir, 0, , "ahk_id " ch)
         }
     }
@@ -2301,28 +2545,32 @@ ScrollPosFromThumbY(thumbY) {
 }
 
 SetScrollPos(newPos) {
-    global ChildGui, CurrentScrollPos, Slider
+    global ContentGui, CurrentScrollPos, Slider
+
+    if (!IsSet(ContentGui) || ContentGui == "")
+        return
 
     newPos := Max(0, Min(Round(newPos), ScrollMaxOffset()))
     if (newPos = CurrentScrollPos)
         return
 
-    hwnd := ChildGui.Hwnd
+    hwnd := ContentGui.Hwnd
     DllCall("ScrollWindow", "Ptr", hwnd, "Int", 0, "Int", CurrentScrollPos - newPos, "Ptr", 0, "Ptr", 0)
     CurrentScrollPos := newPos
-    Slider.Move(, ScrollThumbY(newPos))
+    if (IsSet(Slider) && Slider)
+        Slider.Move(, ScrollThumbY(newPos))
     DllCall("UpdateWindow", "Ptr", hwnd)
 }
 
 TryBeginScrollDrag() {
-    global ChildGui, Slider, SliderX, SliderW, SliderH, CurrentScrollPos
+    global ContentGui, Slider, SliderX, SliderW, SliderH, CurrentScrollPos, FrameH
     global ScrollDragging, ScrollDragGrab
 
-    if (!IsSet(ChildGui) || !ChildGui || !IsSet(Slider))
+    if (!IsSet(ContentGui) || ContentGui == "" || !IsSet(Slider))
         return false
     if (ScrollMaxOffset() <= 0)
         return false
-    if !DllCall("user32\IsWindowVisible", "Ptr", ChildGui.Hwnd, "Int")
+    if !DllCall("user32\IsWindowVisible", "Ptr", ContentGui.Hwnd, "Int")
         return false
 
     oldMode := A_CoordModeMouse
@@ -2330,13 +2578,14 @@ TryBeginScrollDrag() {
     MouseGetPos(&screenX, &screenY)
     CoordMode("Mouse", oldMode)
 
-    try WinGetPos(&childX, &childY, , &childH, "ahk_id " ChildGui.Hwnd)
+    try WinGetPos(&childX, &childY, , , "ahk_id " ContentGui.Hwnd)
     catch
         return false
 
     localX := screenX - childX
     localY := screenY - childY
-    if (localY < 0 || localY > childH)
+    
+    if (localY < 0 || localY > FrameH)
         return false
     if (localX < SliderX - 5 || localX > SliderX + SliderW + 5)
         return false
@@ -2355,14 +2604,14 @@ TryBeginScrollDrag() {
 }
 
 ScrollDragWatch() {
-    global ChildGui, ScrollDragging, ScrollDragGrab
+    global ContentGui, ScrollDragging, ScrollDragGrab
 
     try {
-        if (!ScrollDragging || !GetKeyState("LButton", "P") || !IsSet(ChildGui) || !ChildGui) {
+        if (!ScrollDragging || !GetKeyState("LButton", "P") || !IsSet(ContentGui) || ContentGui == "") {
             StopScrollDrag()
             return
         }
-        childHwnd := ChildGui.Hwnd
+        childHwnd := ContentGui.Hwnd
         if (!childHwnd || !WinExist("ahk_id " childHwnd)) {
             StopScrollDrag()
             return
@@ -2382,8 +2631,6 @@ ScrollDragWatch() {
 
         SetScrollPos(ScrollPosFromThumbY(screenY - childY - ScrollDragGrab))
     } catch Error as err {
-        ; A destroyed control/window or any unexpected GUI error must not leave
-        ; the high-frequency drag callback alive.
         StopScrollDrag()
     }
 }
@@ -2590,12 +2837,15 @@ ClearStrat1(ctrl, *) {
     Strategy1Ctrl.Value := ""
     Strategy1Path := ""
     IniWrite(" ", SettingsFile, "Options", "Strategy1")
+    UpdateStrategyButtons()
 }
+
 ClearStrat2(ctrl, *) {
     global Strategy2Path
     Strategy2Ctrl.Value := ""
     Strategy2Path := ""
     IniWrite(" ", SettingsFile, "Options", "Strategy2")
+    UpdateStrategyButtons()
 }
 SaveStrat1(ctrl, *) {
     global Strategy1Path, Strategy1Ctrl
@@ -9223,6 +9473,7 @@ HandleExit(ExitReason, ExitCode) {
 
 CleanupGdip(exitReason, exitCode) {
     global pToken
+    CleanupRenderedBitmaps()
     Gdip_Shutdown(pToken)
 }
 

--- a/Main.ahk
+++ b/Main.ahk
@@ -1137,42 +1137,41 @@ global CurrentStratTabMode := ""
 SwitchStrategiesTab(mode) {
     global BtnCommStrats, BtnMyStrats, IsRenderingStrategies, CurrentStratTabMode
     
-    ; If the user clicks the tab that is already selected, do nothing.
-    if (CurrentStratTabMode == mode)
-        return
-        
     if (IsRenderingStrategies)
         return
         
     IsRenderingStrategies := true
-    CurrentStratTabMode := mode
     
-    CleanupRenderedBitmaps()
-    
-    if (mode == "Community") {
-        BtnCommStrats.IsSelected := true
-        BtnMyStrats.IsSelected := false
+    try {
+        CleanupRenderedBitmaps()
         
-        BtnCommStrats.Opt("Background222222")
-        BtnCommStrats.SetFont("c3A86FF Bold")
-        BtnMyStrats.Opt("Background0e0e0f")
-        BtnMyStrats.SetFont("cFFFFFF Norm")
-    } else {
-        BtnCommStrats.IsSelected := false
-        BtnMyStrats.IsSelected := true
+        if (mode == "Community") {
+            BtnCommStrats.IsSelected := true
+            BtnMyStrats.IsSelected := false
+            
+            BtnCommStrats.Opt("Background222222")
+            BtnCommStrats.SetFont("c3A86FF Bold")
+            BtnMyStrats.Opt("Background0e0e0f")
+            BtnMyStrats.SetFont("cFFFFFF Norm")
+        } else {
+            BtnCommStrats.IsSelected := false
+            BtnMyStrats.IsSelected := true
+            
+            BtnMyStrats.Opt("Background222222")
+            BtnMyStrats.SetFont("c3A86FF Bold")
+            BtnCommStrats.Opt("Background0e0e0f")
+            BtnCommStrats.SetFont("cFFFFFF Norm")
+        }
         
-        BtnMyStrats.Opt("Background222222")
-        BtnMyStrats.SetFont("c3A86FF Bold")
-        BtnCommStrats.Opt("Background0e0e0f")
-        BtnCommStrats.SetFont("cFFFFFF Norm")
+        BtnCommStrats.Redraw()
+        BtnMyStrats.Redraw()
+        
+        RenderStrategies(mode)
+        
+        CurrentStratTabMode := mode
+    } finally {
+        IsRenderingStrategies := false
     }
-    
-    BtnCommStrats.Redraw()
-    BtnMyStrats.Redraw()
-    
-    RenderStrategies(mode)
-    
-    IsRenderingStrategies := false
 }
 
 RenderStrategies(mode := "Community") {
@@ -2436,21 +2435,39 @@ UpdateStrategyButtons() {
         width := HasProp(ctrl, "IsSmallBtn") && ctrl.IsSmallBtn ? 145 : 220
         
         hBtnNormal := CreateGradientButton(width, 38, 8, loadColor1, loadColor2, "0x40000000", "0x5dffffff", btnText, UIFont(), isLoaded ? (width==145?10:12) : 14, 1)
-        hBtnHover := CreateGradientButton(width, 38, 8, loadHover1, loadHover2, "0x60000000", "0x5dffffff", btnText, UIFont(), isLoaded ? (width==145?10:12) : 14, 1)
+        if (!isLoaded)
+            hBtnHover := CreateGradientButton(width, 38, 8, loadHover1, loadHover2, "0x60000000", "0x5dffffff", btnText, UIFont(), isLoaded ? (width==145?10:12) : 14, 1)
+        else
+            hBtnHover := hBtnNormal
+
+        ; Dispose the old bitmaps and remove them from the tracking array safely
+        if (HasProp(ctrl, "ImgNormal") && ctrl.ImgNormal) {
+            i := RenderedBitmaps.Length
+            while (i > 0) {
+                if (RenderedBitmaps[i] == ctrl.ImgNormal)
+                    RenderedBitmaps.RemoveAt(i)
+                i--
+            }
+            DisposeBitmap(ctrl.ImgNormal)
+        }
+        if (HasProp(ctrl, "ImgHover") && ctrl.ImgHover && ctrl.ImgHover != ctrl.ImgNormal) {
+            i := RenderedBitmaps.Length
+            while (i > 0) {
+                if (RenderedBitmaps[i] == ctrl.ImgHover)
+                    RenderedBitmaps.RemoveAt(i)
+                i--
+            }
+            DisposeBitmap(ctrl.ImgHover)
+        }
 
         ; Register the new bitmaps to be cleaned up when tabs change
         RenderedBitmaps.Push(hBtnNormal)
         if (!isLoaded)
             RenderedBitmaps.Push(hBtnHover)
 
-        ; Dispose the old bitmaps
-        DisposeBitmap(ctrl.ImgNormal)
-        if (ctrl.ImgHover != ctrl.ImgNormal)
-            DisposeBitmap(ctrl.ImgHover)
-
         ; Apply to UI instantly without a full page refresh
         ctrl.ImgNormal := hBtnNormal
-        ctrl.ImgHover := isLoaded ? hBtnNormal : hBtnHover
+        ctrl.ImgHover := hBtnHover
         ctrl.PicControl.Value := "HBITMAP:*" hBtnNormal
     }
 }
@@ -2496,9 +2513,13 @@ DownloadStrat(ctrl, *) {
 }
 
 EditStratFile(ctrl, *) {
+    global CurrentScrollPos, CurrentStratTabMode
     stratToEdit := ctrl.StratFile
     if FileExist(stratToEdit) {
-        Run("notepad.exe `"" stratToEdit "`"")
+        RunWait("notepad.exe `"" stratToEdit "`"")
+        savedScroll := CurrentScrollPos
+        RenderStrategies(CurrentStratTabMode)
+        SetScrollPos(savedScroll)
     } else {
         MsgBox("Strategy file not found!`n" stratToEdit, "Error", 0x10)
     }
@@ -2766,6 +2787,8 @@ EnableStratRotation(*) {
         ; Keep Auto Settings alongside Auto Equip when rotation controls collapse.
         AutoConfigCtrl.Move(285, 190)
     }
+    
+    UpdateStrategyButtons()
 }
 
 EnableAutoEquip(ctrl, *) {
@@ -2816,8 +2839,10 @@ SelectStrat1(ctrl, *) {
         Strategy1Path := f
         IniWrite(f, SettingsFile, "Options", "Strategy1")
         LoadStrategyFile(f)
+        UpdateStrategyButtons()
     }
 }
+
 SelectStrat2(ctrl, *) {
     global Strategy2Path
     targDir := RecordingsDir
@@ -2830,6 +2855,7 @@ SelectStrat2(ctrl, *) {
         Strategy2Ctrl.Value := f
         Strategy2Path := f
         IniWrite(f, SettingsFile, "Options", "Strategy2")
+        UpdateStrategyButtons()
     }
 }
 ClearStrat1(ctrl, *) {
@@ -2847,16 +2873,23 @@ ClearStrat2(ctrl, *) {
     IniWrite(" ", SettingsFile, "Options", "Strategy2")
     UpdateStrategyButtons()
 }
+
 SaveStrat1(ctrl, *) {
     global Strategy1Path, Strategy1Ctrl
     Strategy1Path := Strategy1Ctrl.Text
     IniWrite(Strategy1Ctrl.Text, SettingsFile, "Options", "Strategy1")
+    SetTimer(DebouncedUpdateStrategyButtons, -500)
 }
 
 SaveStrat2(ctrl, *) {
     global Strategy2Path, Strategy2Ctrl
     Strategy2Path := Strategy2Ctrl.Text
     IniWrite(Strategy2Ctrl.Text, SettingsFile, "Options", "Strategy2")
+    SetTimer(DebouncedUpdateStrategyButtons, -500)
+}
+
+DebouncedUpdateStrategyButtons() {
+    UpdateStrategyButtons()
 }
 
 StartStrategy(*) {


### PR DESCRIPTION
### Changes
- Added "Community" and "My Strat" windows in Main
- Made editing strategies under "My Strat" window easier
- If strategy that is currently loaded is also located in "Community" or "My Strat" window it will change the Load button to "Currently Loaded" 

### Test Environment & QA Results
- **Environment:** Windows 11, local `dev` build baseline (PowerShell 7 / Python 3.x / AHK 2.0).
- **Automated Validation:**
  - `python tests/test_source_contracts.py .` -> PASS
  - `python tests/test_reported_runtime_fixes.py .` -> PASS
  - `python tests/validate_repo.py .` -> PASS
  - `python tests/lint_strategies.py .` -> PASS
  - `pwsh ./tools/validate_powershell.ps1` -> PASS
  - `pwsh ./tests/safe_updater_smoke.ps1` -> PASS
  - `pwsh ./tools/validate_ahk.ps1` -> PASS
- **Manual GUI QA (`Main.ahk`):**
  - Confirmed `Main.ahk` launches cleanly with no AHK load errors.
  - Verified "Community" and "My Strat" windows/tabs open and render correctly.
  - Verified strategy editing functionality under "My Strat".
  - Verified Load button dynamically updates to "Currently Loaded" for active strategies.
  - Confirmed main UI buttons (Start/Stop/Settings) retain expected layout and hover states.