### PR TITLE
feat: add profiles, improve the interface, and expand bot commands

### DIFF
--- a/Main.ahk
+++ b/Main.ahk
@@ -53,7 +53,9 @@ if (A_PtrSize == 4) {
 #Include lib\ImageSearch\ImageSearch.ahk
 #Include *i lib\JSON.ahk
 #Include submacros\updater.ahk
+#Include *i lib\Profiles.ahk
 #Include lib\Discord.ahk
+#Include *i lib\DiscordCommands.ahk
 #Include lib\RuntimeLog.ahk
 #Include lib\auto_settings.ahk
 
@@ -147,6 +149,7 @@ global AppDataOpt := A_AppData "\Ultimate_Macro\Options"
 global SettingsFile := AppDataOpt "\Settings.tds"
 global BotSettings := AppDataOpt "\Discord-Bot-Settings.ini"
 global RecordingsDir := A_AppData "\Ultimate_Macro\Recordings"
+global ProfilesDir := A_AppData "\Ultimate_Macro\Profiles"
 global StateFile := A_AppData "\Ultimate_Macro\state.ini"
 
 global StratsDir := A_WorkingDir "\Resources\Strats"
@@ -162,6 +165,8 @@ if !DirExist(AppDataOpt)
     DirCreate(AppDataOpt)
 if !DirExist(RecordingsDir)
     DirCreate(RecordingsDir)
+if !DirExist(ProfilesDir)
+    DirCreate(ProfilesDir)
 
 ;INI READS
 global VipLink := IniRead(SettingsFile, "Options", "VipLink", "")
@@ -185,6 +190,7 @@ global BotToken := IniRead(BotSettings, "Token", "BotToken", "")
 global BotEnabled := IniRead(BotSettings, "Settings", "Enabled", 0)
 global ChannelID := IniRead(BotSettings, "Settings", "Channel", "")
 global UserID := IniRead(BotSettings, "Settings", "UserID", "")
+global BotPrefix := IniRead(BotSettings, "Settings", "Prefix", "!")
 ;
 global AutoEquip := IniRead(SettingsFile, "Options", "AutoEquip", 0)
 global AutoConfigureSettings := IniRead(SettingsFile, "Options", "AutoConfigureSettings", 0)
@@ -1726,6 +1732,12 @@ global Tools_Info := MainGui.Add("Text", "x30 y490 w640 h100 Hidden",
     "Additional utilities for optimizing and simplifying the gameplay and automating repetitive actions. It reduces your suffering."
 )
 
+global Tools_Profiles_Section := MainGui.Add("Text", "x30 y325 w300 h22 Hidden", "Profiles & diagnostics")
+global Tools_Profiles_Line := MainGui.Add("Progress", "x30 y348 w640 h1 Hidden Background333333", 0)
+global ProfileExportBtn := MakeActionButton(MainGui, 30, 365, 200, 38, "Export Profile", ExportProfile, "neutral", true)
+global ProfileImportBtn := MakeActionButton(MainGui, 250, 365, 200, 38, "Import Profile", ImportProfile, "neutral", true)
+global ProfileManagerBtn := MakeActionButton(MainGui, 470, 365, 200, 38, "Manage Profiles", ProfileManager, "neutral", true)
+
 global Auto_COA := MainGui.Add("Picture", "x30 y125 w197 h176 Hidden", "Resources/Gui/auto_coa_preview.png")
 
 Auto_COA.OnEvent("Click", RunAutoAbTool)
@@ -2196,7 +2208,8 @@ ShowTabContent(tab) {
         UpgradeDelayCtrl.Value := UpgradeDelay
 
     } else if (tab = "Tab6") {
-        for ctrl in [Tools_Section, Tools_Section_Line, Tools_Info, Auto_COA, Auto_Spin, Auto_Consum]
+        for ctrl in [Tools_Section, Tools_Section_Line, Tools_Info, Tools_Profiles_Section, Tools_Profiles_Line,
+            ProfileExportBtn, ProfileImportBtn, ProfileManagerBtn, Auto_COA, Auto_Spin, Auto_Consum]
             ShowControl(ctrl)
     } else if (tab = "Tab7") {
         Credit_Content.Visible := true
@@ -9743,7 +9756,7 @@ RunAutoConsumableTool(*) {
     }
 }
 
-ProcessCommands(*) {
+LegacyProcessCommands(*) {
     global command_buffer, UserID, RunningStrategy, ChannelID
 
     Discord.GetCommands(ChannelID)

--- a/lib/DiscordCommands.ahk
+++ b/lib/DiscordCommands.ahk
@@ -1,0 +1,272 @@
+ProcessCommands(*) {
+    global command_buffer, UserID, RunningStrategy, ChannelID, BotPrefix, ver, AutorunStartTime, StateFile
+
+    try {
+    Discord.GetCommands(ChannelID)
+
+    for command in command_buffer {
+        rawContent := Trim(command.content)
+        commandPrefix := SubStr(rawContent, 1, 1)
+        if (commandPrefix != "!" && commandPrefix != BotPrefix)
+            continue
+
+        commandText := StrLower(Trim(SubStr(rawContent, 2)))
+        if !RegExMatch(commandText, "^[a-z]+(?:\s+.*)?$")
+            continue
+        content := RegExReplace(commandText, "\s+.*$")
+        argument := Trim(SubStr(commandText, StrLen(content) + 1))
+
+        if (content = "help" || content = "helpm") {
+            helpText := "**Available commands:**\n"
+            helpText .= "\n!help - shows the help menu"
+            helpText .= "\n!screenshot - take and send a screenshot"
+            helpText .= "\n!status - view macro status and statistics"
+            helpText .= "\n!stop - stop the macro"
+            helpText .= "\n!start - start the macro"
+            helpText .= "\n!ping - check whether the bot is online"
+            helpText .= "\n!version - show the macro version"
+            helpText .= "\n!current - show the active strategy and runtime"
+            helpText .= "\n!stats - show wins, losses, and saved resources"
+            helpText .= "\n!exportlogs - upload diagnostic logs"
+            helpText .= "\n!strat - list available strategy files"
+            helpText .= "\n!strat <number> - select and start a strategy"
+            if (BotPrefix != "!")
+                helpText .= "\n\nCustom prefix enabled: " BotPrefix " (both ! and " BotPrefix " work)"
+            Discord.SendEmbed(
+                helpText
+            )
+        }
+
+        else if (content = "ping") {
+            Discord.SendEmbed("Pong! Ultimate Macro TDS bot is online.")
+        }
+
+        else if (content = "version") {
+            Discord.SendEmbed("Ultimate Macro TDS v" ver)
+        }
+
+        else if (content = "current") {
+            strategyPath := IniRead(StateFile, "State", "Strategy", "")
+            if (strategyPath != "")
+                SplitPath(strategyPath, &currentStrategyName)
+            else
+                currentStrategyName := "None selected"
+
+            currentStatus := RunningStrategy ? "Working" : "Stopped"
+            currentRuntime := RunningStrategy ? FormatRuntime(AutorunStartTime) : "Not running"
+            Discord.SendEmbed(
+                "**Macro:** " currentStatus "\n"
+                . "**Strategy:** " currentStrategyName "\n"
+                . "**Runtime:** " currentRuntime
+            )
+        }
+
+        else if (content = "stats") {
+            savedCoins := IniRead(StateFile, "State", "Coins", 0)
+            savedGems := IniRead(StateFile, "State", "Gems", 0)
+            savedExp := IniRead(StateFile, "State", "EXP", 0)
+            totalTriumphs := IniRead(StateFile, "State", "TotalTriumphs", 0)
+            totalLosses := IniRead(StateFile, "State", "TotalLosses", 0)
+            totalMatches := totalTriumphs + totalLosses
+            winrate := (totalMatches > 0) ? Round((totalTriumphs / totalMatches) * 100) : 0
+
+            Discord.SendEmbed(
+                "**Stats**\n"
+                . "**Wins:** " totalTriumphs " | **Losses:** " totalLosses " | **Win rate:** " winrate "%\n"
+                . "**Coins:** " savedCoins " | **Gems:** " savedGems " | **EXP:** " savedExp
+            )
+        }
+
+        else if (content = "exportlogs") {
+            ExportLogsToDiscord()
+        }
+
+        else if (content = "strat") {
+            if (argument = "")
+                ListBotStrategies()
+            else
+                SelectBotStrategy(argument)
+        }
+        
+        else if (content = "screenshot") {
+            pBitmap := Gdip_BitmapFromScreen()
+            Discord.SendScreenshot(pBitmap, "Requested Screenshot")
+        }
+        
+        else if (content = "status") {
+            status := "stopped"
+            if (RunningStrategy)
+                status := "working"
+
+            savedCoins := IniRead(StateFile, "State", "Coins", 0)
+            savedGems := IniRead(StateFile, "State", "Gems", 0)
+            savedExp := IniRead(StateFile, "State", "EXP", 0)
+            
+            totalTriumphs := IniRead(StateFile, "State", "TotalTriumphs", 0)
+            totalLosses := IniRead(StateFile, "State", "TotalLosses", 0)
+            totalMatches := totalTriumphs + totalLosses
+            winrate := (totalMatches > 0) ? Round((totalTriumphs / totalMatches) * 100) : 0
+            wlRatio := (totalLosses > 0) ? Round(totalTriumphs / totalLosses, 1) : totalTriumphs
+
+            runtime := FormatRuntime(AutorunStartTime)
+
+            autorunStart := IniRead(StateFile, "State", "StartTime", 0)
+            coinsPerHour := 0, gemsPerHour := 0, expPerHour := 0
+            if (autorunStart > 0) {
+                elapsedMs := A_TickCount - autorunStart
+                elapsedHours := elapsedMs / 3600000
+                if (elapsedHours > 0.001) {
+                    coinsPerHour := Round(savedCoins / elapsedHours)
+                    gemsPerHour := Round(savedGems / elapsedHours)
+                    expPerHour := Round(savedExp / elapsedHours)
+                }
+            }
+            
+            currentStrategy := IniRead(StateFile, "State", "Strategy", "")
+
+            SplitPath(currentStrategy, &stratName)
+            
+            if (RunningStrategy) {
+                statusMsg := "**Macro Status:** Working\n"
+                statusMsg .= "**Runtime:** " runtime "\n\n"
+                statusMsg .= "**Current Strategy:** " stratName "\n\n"
+                statusMsg .= "+" savedCoins " **Coins**\t+" savedGems " **Gems**\t+" savedExp " **EXP**\n"
+                statusMsg .= coinsPerHour " Coins/h\t" gemsPerHour " Gems/h\t" expPerHour " EXP/h\n\n"
+                statusMsg .= "**Total Matches:** " totalMatches "\t**Wins:** " totalTriumphs "\t**Losses:** " totalLosses "\n"
+                statusMsg .= "**Winrate:** " winrate "%\t**W/L Ratio:** " wlRatio
+            } else {
+                statusMsg := "**Macro Status:** Stopped"
+            }
+
+            currentTime := A_Hour ":" A_Min ":" A_Sec
+            statusMsg .= "\n-# Ultimate Macro Bot • " currentTime
+
+            Discord.SendEmbed(statusMsg, "3447003")
+        }
+
+        else if (content = "stop") {
+            if (RunningStrategy) {
+                Discord.SendEmbed("Stopping the macro..", "56320")
+                id := Discord.GetMessageAPI()
+                StopStrategy()
+            } else {
+                Discord.SendEmbed("Failed to stop: the macro is not running!", "16515072")
+            }
+        }
+
+        else if (content = "start") {
+            if (RunningStrategy) {
+                Discord.SendEmbed("Failed to start: the macro is already running!", "16515072")
+            } else {
+                Discord.SendEmbed("Starting the macro..", "56320")
+                SetTimer(StartStrategy, -100)
+            }
+        }
+    }
+    
+    } catch Error as err {
+        LogToConsole("Discord command error: " err.Message, true)
+    }
+
+    command_buffer := []
+}
+
+ExportLogsToDiscord() {
+    global LogLines
+    try {
+        report := "**Recent diagnostic log**\n"
+        if (LogLines.Length = 0) {
+            report .= "No in-memory log lines are available."
+        } else {
+            startAt := Max(1, LogLines.Length - 18)
+            loop LogLines.Length - startAt + 1
+                report .= "\n" LogLines[startAt + A_Index - 1]
+        }
+        Discord.SendEmbed(SubStr(report, 1, 3900))
+    } catch Error as err {
+        Discord.SendEmbed("Could not export diagnostics: " err.Message)
+    }
+}
+
+ListBotStrategies() {
+    global BotStrategyChoices, BotStrategyChoiceTime, StratsDir, RecordingsDir, BotPrefix
+
+    choices := []
+    if DirExist(StratsDir) {
+        Loop Files, StratsDir "\\*.strat", "F" {
+            choices.Push({name: A_LoopFileName, path: A_LoopFileFullPath})
+            if (choices.Length >= 25)
+                break
+        }
+    }
+
+    if (choices.Length < 25 && DirExist(RecordingsDir)) {
+        Loop Files, RecordingsDir "\\*.strat", "F" {
+            choices.Push({name: A_LoopFileName, path: A_LoopFileFullPath})
+            if (choices.Length >= 25)
+                break
+        }
+    }
+
+    BotStrategyChoices := choices
+    BotStrategyChoiceTime := A_TickCount
+
+    if (choices.Length = 0) {
+        Discord.SendEmbed("No .strat files were found in the macro's strategy folders.")
+        return
+    }
+
+    message := "**Available strategies:**\n"
+    for index, item in choices
+        message .= "\n" index ". " item.name
+    message .= "\n\nUse " BotPrefix "strat <number> to select one."
+    Discord.SendEmbed(message)
+}
+
+SelectBotStrategy(argument) {
+    global BotStrategyChoices, BotStrategyChoiceTime, Strategy1Path, Strategy2Path, RotateStrategies
+    global Strategy1Ctrl, Strategy2Ctrl, RotateStrategiesCtrl, SettingsFile, RunningStrategy, StateFile, BotPrefix
+
+    if !RegExMatch(argument, "^\d+$") {
+        Discord.SendEmbed("Use a number from the strategy list, for example: " BotPrefix "strat 2")
+        return
+    }
+
+    if (BotStrategyChoices.Length = 0 || A_TickCount - BotStrategyChoiceTime > 300000) {
+        Discord.SendEmbed("The strategy list expired. Request it again before choosing.")
+        ListBotStrategies()
+        return
+    }
+
+    index := Integer(argument)
+    if (index < 1 || index > BotStrategyChoices.Length) {
+        Discord.SendEmbed("That strategy number is not in the current list. Request the list again with " BotPrefix "strat.")
+        return
+    }
+
+    selected := BotStrategyChoices[index]
+    if !FileExist(selected.path) {
+        Discord.SendEmbed("That strategy file is no longer available. Request the list again with " BotPrefix "strat.")
+        return
+    }
+
+    Strategy1Path := selected.path
+    Strategy2Path := ""
+    RotateStrategies := 0
+    Strategy1Ctrl.Value := selected.path
+    Strategy2Ctrl.Value := ""
+    RotateStrategiesCtrl.Value := 0
+    IniWrite(Strategy1Path, SettingsFile, "Options", "Strategy1")
+    IniWrite(Strategy2Path, SettingsFile, "Options", "Strategy2")
+    IniWrite(0, SettingsFile, "Options", "RotateStrategies")
+
+    if (RunningStrategy) {
+        IniWrite(1, StateFile, "State", "Running")
+        IniWrite(selected.path, StateFile, "State", "Strategy")
+        Discord.SendEmbed("Selected **" selected.name "**. Restarting the macro with this strategy.")
+        SafeReload()
+    } else {
+        Discord.SendEmbed("Selected **" selected.name "**. Starting the macro with this strategy.")
+        SetTimer(StartStrategy, -100)
+    }
+}

--- a/lib/Profiles.ahk
+++ b/lib/Profiles.ahk
@@ -1,0 +1,388 @@
+; Portable, safe profile import/export.
+; Profile files intentionally contain an allowlist of settings only.
+
+global ProfileDialogGui := 0
+global ProfileDialogResult := 0
+
+ExportProfile(*) {
+    global SettingsFile, RecordingsDir, ProfilesDir, ver
+    global Strategy1Path, Strategy2Path
+    global TimeScaleMode, UseRestartBtn, UsePlayAgainBtn, CheckTheMap
+    global UseNumbersForHotbar, CollectPlaytimeRewards, UseHForUpgrade
+    global PotatoMode, DefaultMouseSpeed, MouseDelay, KeyDelay, UpgradeDelay
+    global RotateStrategies, SwapAmount, SwapUnit, AutoEquip, LegacyMode
+    global ChainKey, BeatKey, CaravanKey, RaiseDeadKey, HologramKey, RepoKey
+    global CancelPlacementKey, UpgradeTowerGKey, UpgradeTowerGBKey
+    global PlaceTowerKey, UpgradeTowerKey, AlignCameraKey, ChangeDJTrackKey
+    global SellTowerKey, DeleteTowerRecordingKey, RecordInputsKey, HoloKey, ChangeTargetsKey
+
+    choices := ShowProfileExportOptions()
+    if !IsObject(choices)
+        return
+    includeOptions := choices["options"]
+    includeHotkeys := choices["hotkeys"]
+    includeStrategies := choices["strategies"]
+
+    defaultName := SafeProfileName(choices["name"]) ".ump"
+    output := FileSelect("S", ProfilesDir "\" defaultName, "Export Ultimate Macro profile", "Ultimate Macro profile (*.ump)")
+    if (output = "")
+        return
+    if !RegExMatch(output, "i)\.ump$")
+        output .= ".ump"
+
+    profile := Map()
+    profile["formatVersion"] := 1
+    profile["application"] := "Ultimate Macro"
+    profile["macroVersion"] := ver
+    profile["createdAt"] := FormatTime(, "yyyy-MM-dd HH:mm:ss")
+    SplitPath(output, &fileName)
+    profile["name"] := choices["name"]
+    profile["description"] := choices["description"]
+    profile["settings"] := Map()
+    s := profile["settings"]
+    s["Options"] := Map(
+        "TimeScaleMode", TimeScaleMode,
+        "UseRestartBtn", UseRestartBtn,
+        "UsePlayAgainBtn", UsePlayAgainBtn,
+        "CheckTheMap", CheckTheMap,
+        "UseNumbers", UseNumbersForHotbar,
+        "CollectPlaytimeRewards", CollectPlaytimeRewards,
+        "UseHotkeyForUpgrade", UseHForUpgrade,
+        "PotatoMode", PotatoMode,
+        "DefaultMouseSpeed", DefaultMouseSpeed,
+        "MouseDelay", MouseDelay,
+        "KeyDelay", KeyDelay,
+        "UpgradeDelay", UpgradeDelay,
+        "RotateStrategies", RotateStrategies,
+        "SwapAmount", SwapAmount,
+        "SwapUnit", SwapUnit,
+        "AutoEquip", AutoEquip,
+        "LegacyMode", LegacyMode
+    )
+    s["Hotkeys"] := Map(
+        "Chain", ChainKey, "Beat", BeatKey, "Caravan", CaravanKey,
+        "RaiseTheDead", RaiseDeadKey, "Hologram", HologramKey, "Repo", RepoKey,
+        "CancelPlacement", CancelPlacementKey, "UpgradeTower", UpgradeTowerGKey,
+        "UpgradeBottom", UpgradeTowerGBKey
+    )
+    s["RecordingHotkeys"] := Map(
+        "PlaceTowerKey", PlaceTowerKey, "UpgradeTowerKey", UpgradeTowerKey,
+        "AlignCameraKey", AlignCameraKey, "ChangeDJTrackKey", ChangeDJTrackKey,
+        "SellTowerKey", SellTowerKey, "DeleteTowerRecordingKey", DeleteTowerRecordingKey,
+        "RecordInputsKey", RecordInputsKey, "HoloKey", HoloKey,
+        "ChangeTargetsKey", ChangeTargetsKey
+    )
+
+    profile["strategies"] := []
+    seenStrategies := Map()
+    if includeStrategies {
+        for path in [Strategy1Path, Strategy2Path] {
+            if (path = "" || !FileExist(path))
+                continue
+            SplitPath(path, &strategyName)
+            if seenStrategies.Has(StrLower(strategyName))
+                continue
+            seenStrategies[StrLower(strategyName)] := true
+            profile["strategies"].Push(Map("fileName", strategyName, "content", FileRead(path, "UTF-8")))
+        }
+    }
+    if !includeOptions
+        profile["settings"].Delete("Options")
+    if !includeHotkeys {
+        profile["settings"].Delete("Hotkeys")
+        profile["settings"].Delete("RecordingHotkeys")
+    }
+
+    preview := "Profile: " profile["name"] "`n`n" ProfileSummary(profile)
+    if (ModernMsgBox("Export preview", preview "`nExport this profile?", "YES|NO", "QUESTION") != "YES")
+        return
+
+    try {
+        outputFile := FileOpen(output, "w", "UTF-8")
+        outputFile.Write(JSON.stringify(profile))
+        outputFile.Close()
+        ModernMsgBox("Profile exported", "Your safe profile was exported successfully.`n`n" output, "OK")
+    } catch Error as err {
+        ModernMsgBox("Export failed", "The profile could not be exported.`n`n" err.Message, "OK", "WARNING")
+    }
+}
+
+ImportProfile(*) {
+    global ProfilesDir
+
+    input := FileSelect("3", ProfilesDir, "Import Ultimate Macro profile", "Ultimate Macro profile (*.ump)")
+    if (input = "")
+        return
+    ImportProfileFile(input)
+}
+
+ImportProfileFile(input) {
+    global SettingsFile, RecordingsDir
+
+    try {
+        profile := JSON.parse(FileRead(input, "UTF-8"))
+        if (!profile.Has("formatVersion") || profile["formatVersion"] != 1)
+            throw Error("Unsupported profile format.")
+        if (!profile.Has("settings"))
+            throw Error("The profile does not contain valid settings.")
+        if (profile["settings"].Count = 0 && (!profile.Has("strategies") || profile["strategies"].Length = 0))
+            throw Error("The profile does not contain any importable content.")
+
+        uniqueStrategies := []
+        duplicateStrategies := 0
+        seenStrategies := Map()
+        if profile.Has("strategies") {
+            for item in profile["strategies"] {
+                if (!item.Has("fileName") || !item.Has("content"))
+                    continue
+                strategyKey := StrLower(SafeProfileName(item["fileName"]))
+                if seenStrategies.Has(strategyKey) {
+                    duplicateStrategies++
+                    continue
+                }
+                seenStrategies[strategyKey] := true
+                uniqueStrategies.Push(item)
+            }
+        }
+        strategyCount := uniqueStrategies.Length
+        name := profile.Has("name") ? profile["name"] : "Unnamed profile"
+        message := "Profile: " name "`n"
+        if profile.Has("macroVersion")
+            message .= "Created with macro version: " profile["macroVersion"] "`n"
+        if profile.Has("description") && profile["description"] != ""
+            message .= "Description: " profile["description"] "`n"
+        message .= "`n"
+        previewProfile := Map("settings", profile["settings"], "strategies", uniqueStrategies)
+        message .= ProfileSummary(previewProfile)
+        if (duplicateStrategies > 0)
+            message .= "`nDuplicates removed automatically: " duplicateStrategies
+        message .= "`nPrivate settings such as webhooks, bot tokens, VIP links, usernames, and paths are not included.`n`n"
+        if (ModernMsgBox("Import preview", message, "YES|NO", "QUESTION") != "YES")
+            return
+
+        importOptions := profile["settings"].Has("Options") && ModernMsgBox("Import profile", "Import macro settings?", "YES|NO", "QUESTION") = "YES"
+        importHotkeys := (profile["settings"].Has("Hotkeys") || profile["settings"].Has("RecordingHotkeys")) && ModernMsgBox("Import profile", "Import hotkeys? This may replace your current keybinds.", "YES|NO", "QUESTION") = "YES"
+        importStrategies := strategyCount > 0 && ModernMsgBox("Import profile", "Import the embedded strategy files?", "YES|NO", "QUESTION") = "YES"
+
+        SplitPath(input, , &profileDir, , &profileFile)
+        profileDir := RecordingsDir "\Imported Profiles\" SafeProfileName(name)
+        DirCreate(profileDir)
+        backup := SettingsFile ".profile-backup-" FormatTime(, "yyyyMMdd-HHmmss")
+        if FileExist(SettingsFile)
+            FileCopy(SettingsFile, backup)
+
+        for sectionName, section in profile["settings"] {
+            if (sectionName = "Options" && !importOptions)
+                continue
+            if ((sectionName = "Hotkeys" || sectionName = "RecordingHotkeys") && !importHotkeys)
+                continue
+            for key, value in section {
+                if ProfileSettingAllowed(sectionName, key)
+                    IniWrite(value, SettingsFile, sectionName, key)
+            }
+        }
+
+        imported := []
+        if (importStrategies && strategyCount > 0) {
+            for item in uniqueStrategies {
+                strategyName := SafeProfileName(item["fileName"])
+                if !RegExMatch(strategyName, "i)\.strat$")
+                    strategyName .= ".strat"
+                destination := profileDir "\" strategyName
+                strategyFile := FileOpen(destination, "w", "UTF-8")
+                strategyFile.Write(item["content"])
+                strategyFile.Close()
+                imported.Push(destination)
+            }
+        }
+        if imported.Length > 0 {
+            IniWrite(imported[1], SettingsFile, "Options", "Strategy1")
+            if (imported.Length > 1)
+                IniWrite(imported[2], SettingsFile, "Options", "Strategy2")
+        }
+
+        ModernMsgBox("Profile imported", "Profile imported successfully.`n`nA backup was created at:`n" backup "`n`nThe macro will restart to apply the profile.", "OK")
+        Reload()
+    } catch Error as err {
+        ModernMsgBox("Import failed", "This profile could not be imported safely.`n`n" err.Message, "OK", "WARNING")
+    }
+}
+
+ProfileSummary(profile) {
+    summary := "Included content:`n"
+    if (profile["settings"].Count = 0)
+        summary .= "  - No settings`n"
+    else {
+        for sectionName, section in profile["settings"]
+            summary .= "  - " ProfileSectionLabel(sectionName) ": " section.Count " settings`n"
+    }
+    summary .= "  - Strategy files: "
+    if (!profile.Has("strategies") || profile["strategies"].Length = 0) {
+        summary .= "none`n"
+    } else {
+        summary .= profile["strategies"].Length "`n"
+        for item in profile["strategies"]
+            summary .= "      " item["fileName"] "`n"
+    }
+    return summary
+}
+
+ProfileSectionLabel(sectionName) {
+    switch sectionName {
+        case "Options": return "Macro settings"
+        case "Hotkeys": return "TDS hotkeys"
+        case "RecordingHotkeys": return "Recording hotkeys"
+        default: return sectionName
+    }
+}
+
+SafeProfileName(value) {
+    value := RegExReplace(value, "[<>:" Chr(34) "/|?*]", "_")
+    value := RegExReplace(value, "[. ]+$", "")
+    return (value = "" ? "Imported Profile" : SubStr(value, 1, 80))
+}
+
+ProfileManager(*) {
+    global ProfilesDir, ProfileManagerGui, ProfileListCtrl, MainGui
+    if IsSet(ProfileManagerGui) && IsObject(ProfileManagerGui) {
+        try ProfileManagerGui.Destroy()
+    }
+
+    ProfileManagerGui := Gui("+Owner" MainGui.Hwnd, "Ultimate Macro Profiles")
+    ProfileManagerGui.SetFont("s10", "Segoe UI")
+    ProfileManagerGui.Add("Text", "x20 y18 w450", "Saved profiles")
+    ProfileManagerGui.Add("Text", "x20 y42 w450 c777777", "Import a saved profile, export your current setup, or roll back the last import.")
+    ProfileListCtrl := ProfileManagerGui.Add("ListBox", "x20 y75 w450 h190")
+    ProfileManagerGui.Add("Text", "x20 y278 w450 h55 c777777", "Profiles don’t include personal or private information like webhooks, tokens, server links, run history, logs, or anything confidential. You can always review your `.ump` file before sharing it.")
+    exportBtn := ProfileManagerGui.Add("Button", "x20 y335 w140 h30", "Export current")
+    importBtn := ProfileManagerGui.Add("Button", "x175 y335 w140 h30", "Import selected")
+    rollbackBtn := ProfileManagerGui.Add("Button", "x330 y335 w140 h30", "Rollback last")
+    refreshBtn := ProfileManagerGui.Add("Button", "x20 y375 w140 h28", "Refresh")
+    closeBtn := ProfileManagerGui.Add("Button", "x330 y375 w140 h28", "Close")
+    exportBtn.OnEvent("Click", ExportProfile)
+    importBtn.OnEvent("Click", ProfileManagerImport)
+    rollbackBtn.OnEvent("Click", ProfileManagerRollback)
+    refreshBtn.OnEvent("Click", ProfileManagerRefresh)
+    closeBtn.OnEvent("Click", (*) => ProfileManagerGui.Destroy())
+    ProfileManagerRefresh()
+    ProfileManagerGui.Show("w490 h425")
+}
+
+ProfileManagerRefresh(*) {
+    global ProfilesDir, ProfileListCtrl
+    if !IsSet(ProfileListCtrl)
+        return
+    ProfileListCtrl.Delete()
+    profileCount := 0
+    Loop Files, ProfilesDir "\*.ump", "F" {
+        ProfileListCtrl.Add([A_LoopFileName])
+        profileCount++
+    }
+    if (profileCount = 0)
+        ProfileListCtrl.Add(["No saved profiles found"])
+}
+
+ProfileManagerImport(*) {
+    global ProfilesDir, ProfileListCtrl, ProfileManagerGui
+    selected := ProfileListCtrl.Text
+    if (selected = "" || selected = "No saved profiles found")
+        return
+    if (ModernMsgBox("Import profile", "Import '" selected "'? Your current settings will be backed up first.", "YES|NO", "QUESTION") = "YES") {
+        ProfileManagerGui.Destroy()
+        ImportProfileFile(ProfilesDir "\" selected)
+    }
+}
+
+ProfileManagerRollback(*) {
+    global SettingsFile, ProfileManagerGui
+    latest := ""
+    latestTime := ""
+    Loop Files, SettingsFile ".profile-backup-*", "F" {
+        if (latest = "" || A_LoopFileTimeModified > latestTime) {
+            latest := A_LoopFileFullPath
+            latestTime := A_LoopFileTimeModified
+        }
+    }
+    if (latest = "") {
+        ModernMsgBox("Rollback unavailable", "No automatic profile backup exists yet.", "OK", "WARNING")
+        return
+    }
+    if (ModernMsgBox("Rollback profile", "Restore the previous settings backup? The macro will restart.", "YES|NO", "QUESTION") = "YES") {
+        FileCopy(latest, SettingsFile, 1)
+        ProfileManagerGui.Destroy()
+        Reload()
+    }
+}
+
+ShowProfileExportOptions() {
+    global ProfileDialogGui, ProfileDialogResult, MainGui
+    ProfileDialogResult := 0
+    ProfileDialogGui := Gui("+Owner" MainGui.Hwnd, "Export Ultimate Macro Profile")
+    ProfileDialogGui.SetFont("s10", "Segoe UI")
+    ProfileDialogGui.Add("Text", "x20 y18 w430", "Choose what this profile will contain")
+    ProfileDialogGui.Add("Text", "x20 y45 w110", "Profile name:")
+    nameCtrl := ProfileDialogGui.Add("Edit", "x130 y42 w320 vProfileName", "TDS Profile " FormatTime(, "yyyy-MM-dd"))
+    ProfileDialogGui.Add("Text", "x20 y80 w110", "Description:")
+    ProfileDialogGui.Add("Edit", "x130 y77 w320 h45 vProfileDescription", "Shared TDS Macro setup")
+    ProfileDialogGui.Add("Checkbox", "x20 y140 vExportOptions Checked", "Macro settings")
+    ProfileDialogGui.Add("Text", "x40 y162 w410 c777777", "Delays, timescale, performance, restart, and safe preferences")
+    ProfileDialogGui.Add("Checkbox", "x20 y188 vExportHotkeys Checked", "Hotkeys")
+    ProfileDialogGui.Add("Text", "x40 y210 w410 c777777", "TDS ability keys and recording hotkeys")
+    ProfileDialogGui.Add("Checkbox", "x20 y236 vExportStrategies Checked", "Selected strategies")
+    ProfileDialogGui.Add("Text", "x40 y258 w410 c777777", "Embeds strategy contents instead of personal file paths")
+    ProfileDialogGui.Add("Text", "x20 y292 w430 h65 c777777", "Profiles don’t include personal or private information like webhooks, tokens, server links, run history, logs, or anything confidential. You can always review your `.ump` file before sharing it.")
+    ok := ProfileDialogGui.Add("Button", "x250 y355 w95 h30", "Continue")
+    cancel := ProfileDialogGui.Add("Button", "x355 y355 w95 h30", "Cancel")
+    ok.OnEvent("Click", ProfileExportConfirm)
+    cancel.OnEvent("Click", ProfileDialogCancel)
+    ProfileDialogGui.OnEvent("Close", ProfileDialogCancel)
+    ProfileDialogGui.Show("w470 h405")
+    WinWaitClose("ahk_id " ProfileDialogGui.Hwnd)
+    return ProfileDialogResult
+}
+
+ProfileExportConfirm(*) {
+    global ProfileDialogGui, ProfileDialogResult
+    values := ProfileDialogGui.Submit()
+    name := Trim(values.ProfileName)
+    if (name = "") {
+        ModernMsgBox("Missing name", "Enter a profile name first.", "OK", "WARNING")
+        return
+    }
+    ProfileDialogResult := Map(
+        "name", SubStr(name, 1, 80),
+        "description", SubStr(Trim(values.ProfileDescription), 1, 300),
+        "options", values.ExportOptions = 1,
+        "hotkeys", values.ExportHotkeys = 1,
+        "strategies", values.ExportStrategies = 1
+    )
+    if (!ProfileDialogResult["options"] && !ProfileDialogResult["hotkeys"] && !ProfileDialogResult["strategies"]) {
+        ModernMsgBox("Nothing selected", "Select at least one category to export.", "OK", "WARNING")
+        ProfileDialogResult := 0
+        return
+    }
+    ProfileDialogGui.Destroy()
+}
+
+ProfileDialogCancel(*) {
+    global ProfileDialogGui, ProfileDialogResult
+    ProfileDialogResult := 0
+    try ProfileDialogGui.Destroy()
+}
+
+ProfileSettingAllowed(section, key) {
+    allowed := Map(
+        "Options", ["TimeScaleMode", "UseRestartBtn", "UsePlayAgainBtn", "CheckTheMap", "UseNumbers", "CollectPlaytimeRewards", "UseHotkeyForUpgrade", "PotatoMode", "DefaultMouseSpeed", "MouseDelay", "KeyDelay", "UpgradeDelay", "RotateStrategies", "SwapAmount", "SwapUnit", "AutoEquip", "LegacyMode"],
+        "Hotkeys", ["Chain", "Beat", "Caravan", "RaiseTheDead", "Hologram", "Repo", "CancelPlacement", "UpgradeTower", "UpgradeBottom"],
+        "RecordingHotkeys", ["PlaceTowerKey", "UpgradeTowerKey", "AlignCameraKey", "ChangeDJTrackKey", "SellTowerKey", "DeleteTowerRecordingKey", "RecordInputsKey", "HoloKey", "ChangeTargetsKey"]
+    )
+    return allowed.Has(section) && HasValue(allowed[section], key)
+}
+
+HasValue(values, wanted) {
+    for value in values {
+        if (value = wanted)
+            return true
+    }
+    return false
+}


### PR DESCRIPTION
## what changed
- add safe profile import, export, and rollback tools
- add expanded Discord commands for help, status, strategies, screenshots, and diagnostics - also you can now add a custom prefix to the discord commands in the discord bot tab
 - the `strat` command offers a change of strats just by using the bot, do (prefix)strat, then select it by doing `strat [n]`
- preserve the current dev runtime and its safety hardening
- improved the settings page and tool page
 - settings page: removed the clogged of buttons and added an Advanced Settings menu, where delays, potato mode, legacy, vip, etc is
  - tools page: removed the static images with a good explained short text, the profile features and a export logs feature

## testing
- `python tests/test_source_contracts.py`
- `python tests/test_reported_runtime_fixes.py`
- `git diff --check`
- tested all of this with a real live supervised strategy run (discord commands, profile imports, exports, rollbacks, etc)

AutoHotkey native validation was not run because AutoHotkey64.exe was not available on PATH