### PR TITLE
Fix v1.3.5 settings keybind status routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Fixed
 
+- Fixed Settings hotkey status messages so TDS Keybinds and Recording Hotkeys update only their own status text
 - Fixed DJ track switching intermittently clicking unrelated red/green/purple UI by restricting detection to the tower panel and adding one bounded confirmation click when Roblox swallows the first input
 - Fixed placement failure classification so insufficient cash keeps the exact recorded coordinates, while only an explicit "cannot place here" response is allowed to move to an offset
 - Fixed unresolved placement retries drifting towers away from older strategy coordinates; unknown failures now retry the same spot and fail safely instead of guessing a new position

--- a/Main.ahk
+++ b/Main.ahk
@@ -165,6 +165,7 @@ global ToolPreviewWatch := Map()
 global HoverHostHwnds := Map()
 global HotkeyFields := []
 global ActiveHotkeyCapture := 0
+global PendingKeybindStatusSection := ""
 
 global WebhookCheckedLink := ""
 global WebhookCheckedState := ""
@@ -1979,6 +1980,9 @@ global Tab5_Lbl99 := SettingsPanel.Add("Text", "x0 y147 w86 h20 0x200 Background
 SettingsPanel.SetFont("s9 w400 c000000")
 global CancelPlacementKeyCtrl := SettingsPanel.Add("Edit", "x90 y147 w40 h20 Center Limit1", CancelPlacementKey)
 
+SettingsPanel.SetFont("s8 w400 c7E848E", UIFont())
+global Tab5_TDSKeybindStatus := SettingsPanel.Add("Text", "x0 y175 w300 h18 Background121212", "")
+
 SettingsPanel.SetFont("s10 w400 c3A86FF", UIFont())
 global Tab5_Section2 := SettingsPanel.Add("Text", "x330 y8 w290 h22 BackgroundTrans", "Macro Settings")
 global Tab5_Line2 := SettingsPanel.Add("Progress", "x330 y31 w296 h1 Background333333", 0)
@@ -2065,7 +2069,7 @@ global RaiseDeadTEXT := SettingsPanel.Add("Text", "x428 y359 w104 h22 0x200 Back
 global ChangeTargetsCTRL := MakeHotkeyField(SettingsPanel, 534, 359, 92, 22, ChangeTargetsKey)
 
 SettingsPanel.SetFont("s8 w400 c7E848E", UIFont())
-global Tab5_KeybindStatus := SettingsPanel.Add("Text", "x0 y389 w626 h18 Background121212", "")
+global Tab5_RecordingHotkeyStatus := SettingsPanel.Add("Text", "x0 y389 w626 h18 Background121212", "")
 
 SettingsPanel.SetFont("s10 w400 c3A86FF", UIFont())
 global Tab5_Section4 := SettingsPanel.Add("Text", "x0 y416 w290 h22 BackgroundTrans", "Other Settings")
@@ -2652,7 +2656,8 @@ ShowTabContent(tab) {
         KeyDelayTxt.Value := KeyDelay
         RefreshHotkeyDisplays()
 
-        SetKeybindStatus("")
+        SetTDSKeybindStatus("")
+        SetRecordingHotkeyStatus("")
         ShowSettingsPage()
     } else if (tab = "Tab6") {
         for ctrl in [Tools_Section, Tools_Section_Line, Tools_Info, Tools_Profiles_Section, Tools_Profiles_Line,
@@ -2982,14 +2987,42 @@ SetStatusLabel(ctrl, text, color := "") {
     RepaintTransparentControl(ctrl)
 }
 
-SetKeybindStatus(text, isError := false) {
-    global Tab5_KeybindStatus
-    if (!IsSet(Tab5_KeybindStatus) || !Tab5_KeybindStatus)
+SetTDSKeybindStatus(text, isError := false) {
+    global Tab5_TDSKeybindStatus
+    if (!IsSet(Tab5_TDSKeybindStatus) || !Tab5_TDSKeybindStatus)
         return
-    SetStatusLabel(Tab5_KeybindStatus, text, isError ? "FF6B6B" : "7E848E")
+    SetStatusLabel(Tab5_TDSKeybindStatus, text, isError ? "FF6B6B" : "7E848E")
 }
 
-QueueKeybindSave(*) {
+SetRecordingHotkeyStatus(text, isError := false) {
+    global Tab5_RecordingHotkeyStatus
+    if (!IsSet(Tab5_RecordingHotkeyStatus) || !Tab5_RecordingHotkeyStatus)
+        return
+    SetStatusLabel(Tab5_RecordingHotkeyStatus, text, isError ? "FF6B6B" : "7E848E")
+}
+
+SetKeybindStatusForSection(section, text, isError := false) {
+    if (section = "recording") {
+        SetRecordingHotkeyStatus(text, isError)
+    } else if (section = "tds") {
+        SetTDSKeybindStatus(text, isError)
+    } else {
+        SetTDSKeybindStatus(text, isError)
+        SetRecordingHotkeyStatus(text, isError)
+    }
+}
+
+QueueTDSKeybindSave(*) {
+    global PendingKeybindStatusSection
+    PendingKeybindStatusSection := "tds"
+    SetTDSKeybindStatus("Saving TDS keybinds...")
+    QueueSettingSave("keybinds", AutoSaveKeybinds, 600)
+}
+
+QueueRecordingHotkeySave(*) {
+    global PendingKeybindStatusSection
+    PendingKeybindStatusSection := "recording"
+    SetRecordingHotkeyStatus("Saving recording hotkeys...")
     QueueSettingSave("keybinds", AutoSaveKeybinds, 600)
 }
 
@@ -2998,7 +3031,10 @@ AutoSaveKeybinds(*) {
     global RaiseDeadKey, HologramKey, RepoKey
     global PlaceTowerKey, UpgradeTowerKey, AlignCameraKey, ChangeDJTrackKey, SellTowerKey
     global DeleteTowerRecordingKey, RecordInputsKey, HoloKey, ChangeTargetsKey
+    global PendingKeybindStatusSection
 
+    statusSection := PendingKeybindStatusSection
+    PendingKeybindStatusSection := ""
     ClearPendingSettingSave("keybinds")
 
     tempChainKey := FirstKeyChar(ChainKeyCtrl.Value, ChainKey)
@@ -3044,11 +3080,11 @@ AutoSaveKeybinds(*) {
     usedKeys := Map()
     for item in KeysToCheck {
         if (item.val = "") {
-            SetKeybindStatus("Not saved: " item.name " has no key assigned.", true)
+            SetKeybindStatusForSection(statusSection, "Not saved: " item.name " has no key assigned.", true)
             return
         }
         if usedKeys.Has(item.val) {
-            SetKeybindStatus("Not saved: " usedKeys[item.val] " and " item.name " use the same key.", true)
+            SetKeybindStatusForSection(statusSection, "Not saved: " usedKeys[item.val] " and " item.name " use the same key.", true)
             return
         }
         usedKeys[item.val] := item.name
@@ -3100,7 +3136,13 @@ AutoSaveKeybinds(*) {
     SaveRecordingHotkeySetting("ChangeTargetsKey", ChangeTargetsKey)
     SaveRecordingHotkeySetting("HoloKey", HoloKey)
 
-    SetKeybindStatus("Keybinds saved.")
+    if (statusSection = "recording")
+        savedStatus := "Recording hotkeys saved."
+    else if (statusSection = "tds")
+        savedStatus := "TDS keybinds saved."
+    else
+        savedStatus := "Keybinds saved."
+    SetKeybindStatusForSection(statusSection, savedStatus)
 }
 
 FirstKeyChar(value, fallback) {
@@ -3162,11 +3204,11 @@ WireSettingsAutoSave() {
 
     for ctrl in [ChainKeyCtrl, BeatKeyCtrl, CaravanKeyCtrl, RaiseDeadKeyCtrl, HologramKeyCtrl, RepoKeyCtrl,
         CancelPlacementKeyCtrl, UpgradeTowerGCtrl, UpgradeTowerGBCtrl]
-        ctrl.OnEvent("Change", QueueKeybindSave)
+        ctrl.OnEvent("Change", QueueTDSKeybindSave)
 
     for ctrl in [PlaceTowerKeyCtrl, UpgradeTowerKeyCtrl, AlignCameraKeyCtrl, ChangeDJTrackKeyCtrl,
         SellTowerKeyCtrl, DeleteTowerRecordingKeyCtrl, RecordInputsKeyCtrl, HoloKeyCtrl, ChangeTargetsCTRL]
-        ctrl.OnEvent("Change", QueueKeybindSave)
+        ctrl.OnEvent("Change", QueueRecordingHotkeySave)
 
     UseUpgradeHCtrl.OnEvent("Click", (c, *) => (
         UseHForUpgrade := c.Value,

--- a/tests/test_reported_runtime_fixes.py
+++ b/tests/test_reported_runtime_fixes.py
@@ -1071,6 +1071,45 @@ def validate_discord_tab_behaviour(main: str) -> None:
             "status text must erase what it replaces so messages cannot overlap")
 
 
+
+def validate_keybind_status_routing(main: str) -> None:
+    settings = region(main, 'global Tab5_Section1 :=', 'global Tab5_Section4 :=')
+    status = region(
+        main,
+        'SetTDSKeybindStatus(text, isError := false) {',
+        '\nFirstKeyChar(value, fallback) {',
+    )
+    wiring = region(main, 'WireSettingsAutoSave() {', '\nResetSettingsToDefault(*) {')
+
+    require(
+        "Tab5_TDSKeybindStatus" in settings
+        and "Tab5_RecordingHotkeyStatus" in settings,
+        "TDS and recording hotkeys must have independent status labels",
+    )
+    require(
+        "SetTDSKeybindStatus" in status
+        and "SetRecordingHotkeyStatus" in status,
+        "each keybind section must own its status output",
+    )
+    require(
+        'PendingKeybindStatusSection := "tds"' in status
+        and 'PendingKeybindStatusSection := "recording"' in status,
+        "the shared save must remember which section triggered it",
+    )
+    require(
+        status.count("SetKeybindStatusForSection(statusSection") >= 3,
+        "save and validation results must route back to the triggering section",
+    )
+    require(
+        'ctrl.OnEvent("Change", QueueTDSKeybindSave)' in wiring
+        and 'ctrl.OnEvent("Change", QueueRecordingHotkeySave)' in wiring,
+        "TDS and recording controls must use their own routing callbacks",
+    )
+    require(
+        'ctrl.OnEvent("Change", QueueKeybindSave)' not in wiring,
+        "recording hotkeys must not flash the TDS keybind status",
+    )
+
 def validate_tools_and_theme(main: str, tool_window: str) -> None:
     launch = region(main, "LaunchToolOverPreview(scriptName, previewCtrl) {", "WatchToolPreviews() {")
     watch = region(main, "WatchToolPreviews() {", "RestoreToolPreviews() {")
@@ -1192,6 +1231,7 @@ def main() -> int:
     validate_recording_durability(main_source)
     validate_sell_verification(main_source)
     validate_discord_tab_behaviour(main_source)
+    validate_keybind_status_routing(main_source)
     validate_tools_and_theme(main_source, tool_window_source)
     validate_dark_controls(main_source, tool_window_source, profiles_source)
 


### PR DESCRIPTION
Final v1.3.5 visual/settings fix reported by Ziadod.

Changes:
- Separate TDS Keybinds status text from Recording Hotkeys status text.
- Route autosave/validation messages back to the section that triggered them.
- Preserve global duplicate-key validation and existing hotkey save behavior.
- Add regression coverage in `tests/test_reported_runtime_fixes.py`.
- Document the fix in the v1.3.5 changelog.

Source commit from the private dev mirror: `bc422ffa53276816ae4fdb48271a1c61626b3269`.

This PR targets `release/1.3.5` only and does not modify `main`/1.4.0.