### PR TITLE
Fix stale v1.3.5 keybind regression marker

### DIFF
--- a/tests/test_reported_runtime_fixes.py
+++ b/tests/test_reported_runtime_fixes.py
@@ -1053,7 +1053,7 @@ def validate_discord_tab_behaviour(main: str) -> None:
     refresh = region(main, "RefreshWebhookStatus(*) {", "ConfirmWebhookLink() {")
     confirm = region(main, "ConfirmWebhookLink() {", "QueueWebhookCheck(*) {")
     channel = region(main, "CheckWebhookLink2(*) {", "LoadStrategyFile(file) {")
-    status = region(main, "SetStatusLabel(ctrl, text, color", "SetKeybindStatus(text, isError")
+    status = region(main, "SetStatusLabel(ctrl, text, color", "SetTDSKeybindStatus(text, isError")
 
     require("WebhookCheckedLink" in refresh and "link = WebhookCheckedLink" in refresh,
             "an unchanged webhook must reuse its last verdict instead of hitting Discord again")


### PR DESCRIPTION
CI-only hotfix for the final v1.3.5 Settings keybind-status change.

The runtime was already correct, but `tests/test_reported_runtime_fixes.py` still used the old `SetKeybindStatus(...)` function name as a region boundary after the status-routing split. This updates that single stale marker to `SetTDSKeybindStatus(...)`.

Local validation from the branch:
- `python tests/test_source_contracts.py .` PASS
- `python tests/test_reported_runtime_fixes.py .` PASS
- `git diff --check` clean aside from the expected Windows LF/CRLF working-copy warning

No runtime code changes. No GitHub Release/tag publication.