### PR TITLE
Strip nonessential comments from v1.3.5 packaged scripts

### DIFF
--- a/.github/workflows/v135-candidate.yml
+++ b/.github/workflows/v135-candidate.yml
@@ -3,6 +3,7 @@ name: Build v1.3.5 Final Candidate
 on:
   push:
     branches:
+      - release/1.3.5-final-candidate
       - fix/pizzaroles24/v1.3.5-dj-final
   workflow_dispatch:
 

--- a/tests/test_release_package.py
+++ b/tests/test_release_package.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import argparse
+import os
 import re
+import subprocess
 import sys
+import tempfile
 import zipfile
 from pathlib import Path
 
@@ -51,6 +54,30 @@ FORBIDDEN_SUFFIXES = {
     ".yml",
 }
 
+COMMENT_REDUCTION_TARGETS = (
+    ("Main.ahk", ";"),
+    ("submacros/watchdog.ahk", ";"),
+    ("submacros/safe_update.ps1", "#"),
+    ("_app/ui/app.js", "//"),
+)
+
+UNCHANGED_THIRD_PARTY = (
+    "lib/Gdip_All.ahk",
+    "lib/Gdip_ImageSearch.ahk",
+    "lib/ImageSearch/ImageSearch.ahk",
+    "lib/OCR.ahk",
+    "lib/JSON.ahk",
+    "lib/ImageSearch/image_search.dll",
+)
+
+AHK_PACKAGE_VALIDATION_TARGETS = (
+    "Main.ahk",
+    "submacros/watchdog.ahk",
+    "submacros/auto_ability.ahk",
+    "submacros/auto_open_consumable.ahk",
+    "submacros/auto_spin.ahk",
+)
+
 VERSION_RE = re.compile(r'(?m)^\s*ver\s*:=\s*"([^"]+)"\s*$')
 
 
@@ -63,6 +90,83 @@ def parse_args() -> argparse.Namespace:
 
 def fail(errors: list[str], message: str) -> None:
     errors.append(message)
+
+
+def leading_comment_header(text: str, prefix: str) -> str:
+    lines = text.splitlines(keepends=True)
+    end = 0
+    saw_comment = False
+
+    for index, line in enumerate(lines):
+        stripped = line.lstrip()
+        if not stripped.strip():
+            if saw_comment:
+                end = index + 1
+            continue
+        if stripped.startswith(prefix):
+            if prefix == "#" and stripped.casefold().startswith("#requires"):
+                break
+            saw_comment = True
+            end = index + 1
+            continue
+        break
+
+    return "".join(lines[:end]) if saw_comment else ""
+
+
+def comment_only_count(text: str, prefix: str) -> int:
+    count = 0
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if prefix == "//":
+            if stripped.startswith("//"):
+                count += 1
+        elif stripped.startswith(prefix):
+            if prefix == "#" and stripped.casefold().startswith("#requires"):
+                continue
+            count += 1
+    return count
+
+
+def validate_packaged_ahk(extract_root: Path, errors: list[str]) -> None:
+    if os.name != "nt":
+        return
+
+    auto_hotkey = extract_root / "submacros" / "AutoHotkey64.exe"
+    if not auto_hotkey.is_file():
+        fail(errors, "packaged AutoHotkey64.exe is missing; cannot validate stripped scripts")
+        return
+
+    for relative in AHK_PACKAGE_VALIDATION_TARGETS:
+        script = extract_root / relative
+        if not script.is_file():
+            fail(errors, f"packaged AHK validation target is missing: {relative}")
+            continue
+
+        try:
+            completed = subprocess.run(
+                [
+                    str(auto_hotkey),
+                    "/ErrorStdOut=UTF-8",
+                    "/Validate",
+                    str(script),
+                ],
+                cwd=extract_root,
+                capture_output=True,
+                text=True,
+                timeout=20,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            fail(errors, f"packaged AutoHotkey validation could not run for {relative}: {exc}")
+            continue
+
+        if completed.returncode != 0:
+            output = (completed.stdout + "\n" + completed.stderr).strip()
+            fail(
+                errors,
+                f"packaged AutoHotkey validation failed for {relative}: {output}",
+            )
 
 
 def main() -> int:
@@ -100,6 +204,13 @@ def main() -> int:
             for name in names:
                 relative = Path(name)
                 parts = {part.casefold() for part in relative.parts}
+                normalized_name = name.replace("\\", "/")
+                if (
+                    normalized_name.startswith("/")
+                    or re.match(r"^[A-Za-z]:", normalized_name)
+                    or ".." in Path(normalized_name).parts
+                ):
+                    fail(errors, f"unsafe ZIP entry: {name}")
                 if parts & FORBIDDEN_PARTS:
                     fail(errors, f"developer-only path leaked into release: {name}")
                 if (
@@ -120,6 +231,41 @@ def main() -> int:
                 packaged_app = [name for name in normalized if name.startswith("_app/")]
                 if not packaged_app:
                     fail(errors, "_app runtime exists in source but was not packaged")
+
+            if "Main.ahk" in normalized:
+                packaged_main = archive.read("Main.ahk").decode("utf-8-sig", errors="replace")
+                expected_header = leading_comment_header(main_source, ";")
+                if expected_header and not packaged_main.startswith(expected_header):
+                    fail(errors, "Main.ahk attribution/header comments must remain intact")
+
+            for relative, prefix in COMMENT_REDUCTION_TARGETS:
+                source_path = root / relative
+                if not source_path.is_file() or relative not in normalized:
+                    continue
+                source_text = source_path.read_text(encoding="utf-8-sig", errors="replace")
+                packaged_text = archive.read(relative).decode("utf-8-sig", errors="replace")
+                source_count = comment_only_count(source_text, prefix)
+                packaged_count = comment_only_count(packaged_text, prefix)
+                if source_count > 0 and packaged_count >= source_count:
+                    fail(
+                        errors,
+                        f"nonessential comments were not reduced in packaged script: {relative}",
+                    )
+
+            for relative in UNCHANGED_THIRD_PARTY:
+                source_path = root / relative
+                if source_path.is_file() and relative in normalized:
+                    if archive.read(relative) != source_path.read_bytes():
+                        fail(
+                            errors,
+                            f"third-party/binary dependency was modified during packaging: {relative}",
+                        )
+
+            if not errors and os.name == "nt":
+                with tempfile.TemporaryDirectory(prefix="ultimate-macro-package-") as temp_dir:
+                    extract_root = Path(temp_dir)
+                    archive.extractall(extract_root)
+                    validate_packaged_ahk(extract_root, errors)
     except zipfile.BadZipFile:
         fail(errors, "release package is not a valid ZIP")
 

--- a/tests/test_release_package.py
+++ b/tests/test_release_package.py
@@ -114,6 +114,10 @@ def leading_comment_header(text: str, prefix: str) -> str:
     return "".join(lines[:end]) if saw_comment else ""
 
 
+def normalized_newlines(text: str) -> str:
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
 def comment_only_count(text: str, prefix: str) -> int:
     count = 0
     for line in text.splitlines():
@@ -235,7 +239,9 @@ def main() -> int:
             if "Main.ahk" in normalized:
                 packaged_main = archive.read("Main.ahk").decode("utf-8-sig", errors="replace")
                 expected_header = leading_comment_header(main_source, ";")
-                if expected_header and not packaged_main.startswith(expected_header):
+                if expected_header and not normalized_newlines(packaged_main).startswith(
+                    normalized_newlines(expected_header)
+                ):
                     fail(errors, "Main.ahk attribution/header comments must remain intact")
 
             for relative, prefix in COMMENT_REDUCTION_TARGETS:

--- a/tools/build_release.py
+++ b/tools/build_release.py
@@ -58,6 +58,48 @@ FORBIDDEN_NAMES = {
     "tower-catalog-status.csv",
 }
 
+COMMENT_STRIP_SUFFIXES = {
+    ".ahk",
+    ".js",
+    ".ps1",
+}
+
+COMMENT_STRIP_EXEMPT_FILES = {
+    "lib/Gdip_All.ahk",
+    "lib/Gdip_ImageSearch.ahk",
+    "lib/HyperSleep.ahk",
+    "lib/ImageSearch/ImageSearch.ahk",
+    "lib/JSON.ahk",
+    "lib/OCR.ahk",
+}
+
+COMMENT_STRIP_EXEMPT_PREFIXES = (
+    "_app/vendor/",
+)
+
+ESSENTIAL_COMMENT_MARKERS = (
+    "copyright",
+    "license",
+    "licence",
+    "original author",
+    "original credit",
+    "author:",
+    "source:",
+    "security:",
+    "warning:",
+    "important:",
+    "do not remove",
+    "must remain",
+    "required by",
+    "requires:",
+    "@ahk2exe",
+    "eslint-",
+    "prettier-",
+    "psscriptanalyzer",
+    "sig # begin signature block",
+    "sig # end signature block",
+)
+
 VERSION_RE = re.compile(r'(?m)^\s*ver\s*:=\s*"([^"]+)"\s*$')
 
 
@@ -141,6 +183,224 @@ def collect_files(root: Path) -> list[Path]:
     return sorted(selected, key=lambda item: item.as_posix().casefold())
 
 
+def is_comment_strip_target(relative: Path) -> bool:
+    normalized = relative.as_posix()
+    normalized_folded = normalized.casefold()
+
+    if relative.suffix.casefold() not in COMMENT_STRIP_SUFFIXES:
+        return False
+    if normalized_folded in {path.casefold() for path in COMMENT_STRIP_EXEMPT_FILES}:
+        return False
+    return not any(
+        normalized_folded.startswith(prefix.casefold())
+        for prefix in COMMENT_STRIP_EXEMPT_PREFIXES
+    )
+
+
+def _is_essential_comment(text: str) -> bool:
+    folded = text.casefold()
+    return any(marker in folded for marker in ESSENTIAL_COMMENT_MARKERS)
+
+
+def _leading_comment_block_end(lines: list[str], prefix: str) -> int:
+    end = 0
+    saw_comment = False
+
+    for index, line in enumerate(lines):
+        stripped = line.lstrip()
+        if not stripped.strip():
+            if saw_comment:
+                end = index + 1
+            continue
+        if stripped.startswith(prefix):
+            if prefix == "#" and stripped.casefold().startswith("#requires"):
+                break
+            saw_comment = True
+            end = index + 1
+            continue
+        break
+
+    return end if saw_comment else 0
+
+
+def _strip_ahk_line_comments(text: str) -> str:
+    lines = text.splitlines(keepends=True)
+    header_end = _leading_comment_block_end(lines, ";")
+    output: list[str] = []
+
+    for index, line in enumerate(lines):
+        stripped = line.lstrip()
+        if index < header_end:
+            output.append(line)
+            continue
+        if stripped.startswith(";"):
+            comment = stripped[1:].strip()
+            if (
+                stripped.startswith(";::")
+                or stripped.startswith("; &")
+                or _is_essential_comment(comment)
+            ):
+                output.append(line)
+            continue
+        output.append(line)
+
+    return "".join(output)
+
+
+def _strip_powershell_line_comments(text: str) -> str:
+    lines = text.splitlines(keepends=True)
+    header_end = _leading_comment_block_end(lines, "#")
+    output: list[str] = []
+    here_string_end = ""
+    in_block_comment = False
+    in_signature_block = False
+
+    for index, line in enumerate(lines):
+        stripped = line.lstrip()
+        compact = stripped.strip()
+        folded = compact.casefold()
+
+        if in_signature_block:
+            output.append(line)
+            if "sig # end signature block" in folded:
+                in_signature_block = False
+            continue
+
+        if "sig # begin signature block" in folded:
+            in_signature_block = True
+            output.append(line)
+            continue
+
+        if here_string_end:
+            output.append(line)
+            if compact == here_string_end:
+                here_string_end = ""
+            continue
+
+        if in_block_comment:
+            output.append(line)
+            if "#>" in compact:
+                in_block_comment = False
+            continue
+
+        if compact.startswith("<#"):
+            in_block_comment = "#>" not in compact[2:]
+            output.append(line)
+            continue
+
+        if re.search(r'@["\']\s*$', line):
+            here_string_end = '"@' if line.rstrip().endswith('@"') else "'@"
+            output.append(line)
+            continue
+
+        if index < header_end:
+            output.append(line)
+            continue
+
+        if stripped.casefold().startswith("#requires"):
+            output.append(line)
+            continue
+
+        if stripped.startswith("#"):
+            comment = stripped[1:].strip()
+            if _is_essential_comment(comment):
+                output.append(line)
+            continue
+
+        output.append(line)
+
+    return "".join(output)
+
+
+def _toggle_js_template_state(line: str, in_template: bool) -> bool:
+    escaped = False
+    index = 0
+    while index < len(line):
+        char = line[index]
+        if escaped:
+            escaped = False
+            index += 1
+            continue
+        if char == "\\":
+            escaped = True
+            index += 1
+            continue
+        if char == "`":
+            in_template = not in_template
+        index += 1
+    return in_template
+
+
+def _strip_js_line_comments(text: str) -> str:
+    lines = text.splitlines(keepends=True)
+    header_end = _leading_comment_block_end(lines, "//")
+    output: list[str] = []
+    in_template = False
+    in_block_comment = False
+
+    for index, line in enumerate(lines):
+        stripped = line.lstrip()
+        compact = stripped.strip()
+
+        if in_block_comment:
+            output.append(line)
+            if "*/" in compact:
+                in_block_comment = False
+            continue
+
+        if in_template:
+            output.append(line)
+            in_template = _toggle_js_template_state(line, in_template)
+            continue
+
+        if compact.startswith("/*"):
+            in_block_comment = "*/" not in compact[2:]
+            output.append(line)
+            continue
+
+        if index < header_end:
+            output.append(line)
+            in_template = _toggle_js_template_state(line, in_template)
+            continue
+
+        if stripped.startswith("//"):
+            comment = stripped[2:].strip()
+            if _is_essential_comment(comment):
+                output.append(line)
+            continue
+
+        output.append(line)
+        in_template = _toggle_js_template_state(line, in_template)
+
+    return "".join(output)
+
+
+def strip_release_comments(relative: Path, data: bytes) -> bytes:
+    if not is_comment_strip_target(relative):
+        return data
+
+    had_bom = data.startswith(b"\xef\xbb\xbf")
+    try:
+        text = data.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        return data
+
+    suffix = relative.suffix.casefold()
+    if suffix == ".ahk":
+        cleaned = _strip_ahk_line_comments(text)
+    elif suffix == ".ps1":
+        cleaned = _strip_powershell_line_comments(text)
+    elif suffix == ".js":
+        cleaned = _strip_js_line_comments(text)
+    else:
+        return data
+
+    encoded = cleaned.encode("utf-8")
+    if had_bom:
+        encoded = b"\xef\xbb\xbf" + encoded
+    return encoded
+
+
 def write_zip(root: Path, output: Path, files: list[Path]) -> str:
     output.parent.mkdir(parents=True, exist_ok=True)
     if output.exists():
@@ -155,10 +415,16 @@ def write_zip(root: Path, output: Path, files: list[Path]) -> str:
     ) as archive:
         for relative in files:
             data = (root / relative).read_bytes()
+            data = strip_release_comments(relative, data)
             info = zipfile.ZipInfo(relative.as_posix(), date_time=(1980, 1, 1, 0, 0, 0))
             info.compress_type = zipfile.ZIP_DEFLATED
             info.external_attr = 0o100644 << 16
-            archive.writestr(info, data, compress_type=zipfile.ZIP_DEFLATED, compresslevel=9)
+            archive.writestr(
+                info,
+                data,
+                compress_type=zipfile.ZIP_DEFLATED,
+                compresslevel=9,
+            )
 
     digest = hashlib.sha256(output.read_bytes()).hexdigest()
     return digest


### PR DESCRIPTION
Tester packaging cleanup requested by the team.

- Removes nonessential first-party full-line comments from packaged AHK/PowerShell/JS scripts at build time.
- Preserves the Main.ahk attribution/header block, required directives, license/security/important comments, third-party/vendor sources, and binaries/DLLs.
- Keeps repository source comments intact for maintainability; only the generated tester/user ZIP is cleaned.
- Adds package-level validation that confirms comments are reduced, protected third-party files remain byte-identical, and packaged AHK scripts still validate after cleanup.
- Makes `release/1.3.5-final-candidate` trigger the tester candidate workflow directly.
- CI run #158 passed on the exact head.

No runtime behavior change. No tag or GitHub Release publication.